### PR TITLE
Add metadata generation for SpatialNodes by level

### DIFF
--- a/multiverse/generator.py
+++ b/multiverse/generator.py
@@ -1,5 +1,6 @@
 # multiverse/generator.py
 
+import random
 from multiverse.node import SpatialNode
 
 LEVELS = [
@@ -15,14 +16,29 @@ LEVELS = [
     "SubatomicParticle"
 ]
 
+def generate_properties(level: str) -> dict:
+    templates = {
+        "Multiverse": {"theme": random.choice(["entropy", "expansion", "paradox"])},
+        "Universe": {"laws_of_physics": random.choice(["Newtonian", "Quantum", "Fractal"])},
+        "Galaxy": {"star_density": random.randint(50, 200)},
+        "Planet": {"gravity": round(random.uniform(0.5, 2.0), 2), "inhabited": random.choice([True, False])},
+        "Region": {"danger_level": random.randint(1, 10)},
+        "Room": {"has_puzzle": random.choice([True, False]), "locked": random.choice([True, False])},
+        "Object": {"interactive": random.choice([True, False])},
+        "Molecule": {"compound_type": random.choice(["organic", "inorganic"])},
+        "Atom": {"element": random.choice(["H", "C", "O", "N", "Fe"])},
+        "SubatomicParticle": {"particle_type": random.choice(["proton", "neutron", "electron"])},
+    }
+    return templates.get(level, {})
+
 def generate_node_hierarchy(seed: int = 42, depth: int = 10, breadth: int = 2) -> SpatialNode:
-    import random
     random.seed(seed)
 
     def _generate(level_index: int) -> SpatialNode:
         level = LEVELS[level_index]
         name = f"{level}_{random.randint(100, 999)}"
-        node = SpatialNode(name=name, level=level)
+        properties = generate_properties(level)
+        node = SpatialNode(name=name, level=level, properties=properties)
 
         if level_index + 1 < depth:
             for _ in range(breadth):

--- a/multiverse/node.py
+++ b/multiverse/node.py
@@ -1,17 +1,17 @@
-# multiverse/node.py
-
 class SpatialNode:
-    def __init__(self, name: str, level: str, children: list = None):
+    def __init__(self, name: str, level: str, children: list = None, properties: dict = None):
         self.name = name
-        self.level = level  # e.g. "Room", "Planet", etc.
+        self.level = level
         self.children = children or []
+        self.properties = properties or {}
 
     def add_child(self, node: "SpatialNode"):
         self.children.append(node)
 
     def __repr__(self, depth=0):
         indent = "  " * depth
-        repr_str = f"{indent}{self.level}: {self.name}\n"
+        props = ", ".join(f"{k}: {v}" for k, v in self.properties.items())
+        repr_str = f"{indent}{self.level}: {self.name} [{props}]\n"
         for child in self.children:
             repr_str += child.__repr__(depth + 1)
         return repr_str


### PR DESCRIPTION
This PR adds structured metadata to each SpatialNode in the multiverse hierarchy.

- Each node level now includes level-specific properties (e.g. gravity for Planets, has_puzzle for Rooms, element for Atoms)
- A new `generate_properties(level: str)` helper populates realistic attributes
- The tree is now rich in contextual data for use in agent behavior, puzzles, and future simulations
