### PR TITLE
Add persistence layer and consciousness module with CLI history

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -1,7 +1,5 @@
-# agents/agent.py
-
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List
 from multiverse.node import SpatialNode
 from agents.behaviors import State, transition, should_avoid
 
@@ -22,7 +20,7 @@ class Agent:
     log: List[AgentLog] = field(default_factory=list)
     visited: List[str] = field(default_factory=list)
 
-    def _record(self, node: SpatialNode, action: str):
+    def _record(self, node: SpatialNode, action: str) -> None:
         self.log.append(AgentLog(
             node_name=node.name,
             level=node.level,
@@ -30,11 +28,11 @@ class Agent:
             action=action,
         ))
 
-    def _act(self, node: SpatialNode):
+    def _act(self, node: SpatialNode) -> bool:
         if self.state == State.EXPLORE:
             if should_avoid(node, self.danger_threshold):
                 self._record(node, f"avoided (danger_level={node.properties.get('danger_level')})")
-                return False  # signal: don't descend
+                return False
             self._record(node, "explored")
 
         elif self.state == State.INTERACT:
@@ -50,13 +48,20 @@ class Agent:
 
         return True
 
-    def traverse(self, node: SpatialNode, max_nodes: int = 50):
-        if len(self.visited) >= max_nodes:
+    def traverse(self, node: SpatialNode, max_nodes: int = 50) -> None:
+        """Reset agent state and traverse the hierarchy rooted at `node`."""
+        self.state = State.IDLE
+        self.log = []
+        self.visited = []
+        self._traverse(node, max_nodes, depth=0)
+
+    def _traverse(self, node: SpatialNode, max_nodes: int, depth: int) -> None:
+        if len(self.visited) >= max_nodes or depth > 500:
             return
-        if node.name in self.visited:
+        if node.id in self.visited:
             return
 
-        self.visited.append(node.name)
+        self.visited.append(node.id)
         self.state = transition(self.state, node)
         should_descend = self._act(node)
 
@@ -64,8 +69,7 @@ class Agent:
             for child in node.children:
                 if len(self.visited) >= max_nodes:
                     break
-                self.state = transition(self.state, child)
-                self.traverse(child, max_nodes)
+                self._traverse(child, max_nodes, depth + 1)
 
     def report(self) -> str:
         lines = [f"Agent '{self.name}' traversal report ({len(self.log)} events):"]

--- a/consciousness/__init__.py
+++ b/consciousness/__init__.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+from multiverse.node import SpatialNode
+
+# Lazy-initialised so the module loads without requiring anthropic to be installed.
+_client: Any = None
+
+_SYSTEM_PREAMBLE = (
+    "You are a sentient entity within a nested multiverse simulation. "
+    "You speak as the location or object you embody — atmospheric, in-world, and brief. "
+    "Never break the fourth wall or reveal that you are an AI. "
+    "Respond in 1–3 sentences only."
+)
+
+
+def _get_client() -> Any:
+    global _client
+    if _client is None:
+        from anthropic import Anthropic
+        _client = Anthropic()
+    return _client
+
+
+def speak(node: SpatialNode, message: str) -> str:
+    """Send `message` to `node` and return its in-character response.
+
+    The shared behavioural preamble is marked for prompt caching so repeated
+    calls across different nodes reuse the cached prefix and avoid redundant
+    token processing.
+    """
+    props = "; ".join(f"{k}={v}" for k, v in node.properties.items())
+    node_context = f"You are {node.name}, a {node.level}. Your nature: {props}."
+
+    response = _get_client().messages.create(
+        model="claude-opus-4-7",
+        max_tokens=256,
+        system=[
+            {
+                "type": "text",
+                "text": _SYSTEM_PREAMBLE,
+                "cache_control": {"type": "ephemeral"},
+            },
+            {
+                "type": "text",
+                "text": node_context,
+            },
+        ],
+        messages=[{"role": "user", "content": message}],
+    )
+    return response.content[0].text
+
+
+def describe(node: SpatialNode) -> str:
+    """Ask the node to introduce itself to a newly arrived traveller."""
+    return speak(node, "Describe yourself to a traveler who has just arrived here.")

--- a/main.py
+++ b/main.py
@@ -1,9 +1,24 @@
-# main.py
-
 import argparse
-from multiverse.generator import generate_node_hierarchy
+
+import persistence
 from agents.agent import Agent
+from multiverse.generator import generate_node_hierarchy
+from multiverse.node import SpatialNode
 from puzzles.engine import PuzzleEngine
+
+
+def _count_nodes(node: SpatialNode) -> int:
+    return 1 + sum(_count_nodes(c) for c in node.children)
+
+
+def _find_node(root: SpatialNode, name: str) -> SpatialNode | None:
+    if root.name == name:
+        return root
+    for child in root.children:
+        found = _find_node(child, name)
+        if found:
+            return found
+    return None
 
 
 def cmd_world(args):
@@ -14,6 +29,9 @@ def cmd_world(args):
         max_breadth=args.max_breadth,
     )
     print(root)
+    node_count = _count_nodes(root)
+    persistence.save_world(args.seed, node_count, args.depth, args.min_breadth, args.max_breadth)
+    print(f"[Saved: seed={args.seed}, {node_count} nodes]")
 
 
 def cmd_agent(args):
@@ -21,6 +39,12 @@ def cmd_agent(args):
     agent = Agent(name=args.name, danger_threshold=args.danger_threshold)
     agent.traverse(root, max_nodes=args.max_nodes)
     print(agent.report())
+    events = [
+        {"node": e.node_name, "level": e.level, "state": e.state.name, "action": e.action}
+        for e in agent.log
+    ]
+    persistence.save_agent_run(args.name, args.seed, len(agent.visited), events)
+    print(f"[Run saved: {len(agent.visited)} nodes visited]")
 
 
 def cmd_puzzles(args):
@@ -36,6 +60,44 @@ def cmd_puzzles(args):
     print(f"Found {len(puzzles)} puzzle(s) in this world.\n")
     for puzzle in puzzles:
         engine.run_puzzle(puzzle)
+        persistence.save_puzzle_result(args.seed, puzzle.name, puzzle.result.name, puzzle.attempts)
+
+
+def cmd_history(args):
+    worlds = persistence.list_worlds()
+    if not worlds:
+        print("No worlds saved yet. Run the 'world' or 'agent' command to generate some.")
+        return
+    print(f"{'Seed':>8}  {'Saved':>20}  {'Nodes':>8}  {'Depth':>6}")
+    print("-" * 50)
+    for w in worlds:
+        print(
+            f"{w['seed']:>8}  {w['created_at']:>20}"
+            f"  {str(w['node_count'] or '?'):>8}  {str(w['max_depth'] or '?'):>6}"
+        )
+        for r in persistence.get_agent_runs(w["seed"]):
+            print(f"          agent '{r['agent_name']}' — {r['nodes_visited']} nodes  ({r['started_at']})")
+
+
+def cmd_speak(args):
+    try:
+        import consciousness
+    except ImportError:
+        print("Consciousness module requires: pip install anthropic")
+        return
+
+    root = generate_node_hierarchy(seed=args.seed)
+    target = _find_node(root, args.node) if args.node else root
+    if target is None:
+        print(f"Node '{args.node}' not found in seed={args.seed}. Run 'world' to see available nodes.")
+        return
+
+    print(f"\n[{target.level}: {target.name}]")
+    try:
+        print(consciousness.speak(target, args.message))
+    except Exception as e:
+        print(f"Error: {e}")
+        print("Ensure ANTHROPIC_API_KEY is set in your environment.")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -46,14 +108,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--seed", type=int, default=42, help="RNG seed (default: 42)")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    # world subcommand
     p_world = sub.add_parser("world", help="Generate and print the world hierarchy")
     p_world.add_argument("--depth", type=int, default=10, help="Max hierarchy depth (default: 10)")
     p_world.add_argument("--min-breadth", type=int, default=1, dest="min_breadth")
     p_world.add_argument("--max-breadth", type=int, default=3, dest="max_breadth")
     p_world.set_defaults(func=cmd_world)
 
-    # agent subcommand
     p_agent = sub.add_parser("agent", help="Run an agent traversal of the world")
     p_agent.add_argument("--name", type=str, default="Scout", help="Agent name (default: Scout)")
     p_agent.add_argument("--danger-threshold", type=int, default=6, dest="danger_threshold",
@@ -62,9 +122,22 @@ def build_parser() -> argparse.ArgumentParser:
                          help="Max nodes to visit (default: 50)")
     p_agent.set_defaults(func=cmd_agent)
 
-    # puzzles subcommand
     p_puzzles = sub.add_parser("puzzles", help="Find and play puzzles in the world")
     p_puzzles.set_defaults(func=cmd_puzzles)
+
+    p_history = sub.add_parser("history", help="Show saved worlds and agent runs")
+    p_history.set_defaults(func=cmd_history)
+
+    p_speak = sub.add_parser("speak", help="Speak to a node using Claude consciousness")
+    p_speak.add_argument("--node", type=str, default=None,
+                         help="Node name to address (default: root of world)")
+    p_speak.add_argument(
+        "--message",
+        type=str,
+        default="Describe yourself to a traveler who has just arrived.",
+        help="Message to send to the node",
+    )
+    p_speak.set_defaults(func=cmd_speak)
 
     return parser
 

--- a/multiverse/node.py
+++ b/multiverse/node.py
@@ -1,14 +1,26 @@
+from __future__ import annotations
+import uuid
+from typing import Any
+
+
 class SpatialNode:
-    def __init__(self, name: str, level: str, children: list = None, properties: dict = None):
+    def __init__(
+        self,
+        name: str,
+        level: str,
+        children: list[SpatialNode] | None = None,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        self.id: str = str(uuid.uuid4())
         self.name = name
         self.level = level
-        self.children = children or []
-        self.properties = properties or {}
+        self.children: list[SpatialNode] = children or []
+        self.properties: dict[str, Any] = properties or {}
 
-    def add_child(self, node: "SpatialNode"):
+    def add_child(self, node: SpatialNode) -> None:
         self.children.append(node)
 
-    def __repr__(self, depth=0):
+    def __repr__(self, depth: int = 0) -> str:
         indent = "  " * depth
         props = ", ".join(f"{k}: {v}" for k, v in self.properties.items())
         repr_str = f"{indent}{self.level}: {self.name} [{props}]\n"

--- a/persistence/__init__.py
+++ b/persistence/__init__.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+_DB_PATH = Path.home() / ".nested-worlds" / "worlds.db"
+
+
+def _connect() -> sqlite3.Connection:
+    _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(_DB_PATH)
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def init_db() -> None:
+    with _connect() as conn:
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS worlds (
+                seed        INTEGER PRIMARY KEY,
+                created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                node_count  INTEGER,
+                max_depth   INTEGER,
+                min_breadth INTEGER,
+                max_breadth INTEGER
+            );
+
+            CREATE TABLE IF NOT EXISTS agent_runs (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_name    TEXT NOT NULL,
+                world_seed    INTEGER NOT NULL,
+                started_at    TEXT NOT NULL DEFAULT (datetime('now')),
+                nodes_visited INTEGER,
+                events        TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS puzzle_results (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                world_seed  INTEGER NOT NULL,
+                puzzle_name TEXT NOT NULL,
+                result      TEXT NOT NULL,
+                attempts    INTEGER NOT NULL,
+                recorded_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+        """)
+
+
+def save_world(seed: int, node_count: int, max_depth: int, min_breadth: int, max_breadth: int) -> None:
+    init_db()
+    with _connect() as conn:
+        conn.execute(
+            """INSERT OR REPLACE INTO worlds (seed, node_count, max_depth, min_breadth, max_breadth)
+               VALUES (?, ?, ?, ?, ?)""",
+            (seed, node_count, max_depth, min_breadth, max_breadth),
+        )
+
+
+def save_agent_run(agent_name: str, world_seed: int, nodes_visited: int, events: list[dict[str, Any]]) -> int:
+    init_db()
+    with _connect() as conn:
+        cur = conn.execute(
+            """INSERT INTO agent_runs (agent_name, world_seed, nodes_visited, events)
+               VALUES (?, ?, ?, ?)""",
+            (agent_name, world_seed, nodes_visited, json.dumps(events)),
+        )
+        return cur.lastrowid
+
+
+def save_puzzle_result(world_seed: int, puzzle_name: str, result: str, attempts: int) -> None:
+    init_db()
+    with _connect() as conn:
+        conn.execute(
+            """INSERT INTO puzzle_results (world_seed, puzzle_name, result, attempts)
+               VALUES (?, ?, ?, ?)""",
+            (world_seed, puzzle_name, result, attempts),
+        )
+
+
+def list_worlds() -> list[dict[str, Any]]:
+    init_db()
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT seed, created_at, node_count, max_depth FROM worlds ORDER BY created_at DESC"
+        ).fetchall()
+        return [{"seed": r[0], "created_at": r[1], "node_count": r[2], "max_depth": r[3]} for r in rows]
+
+
+def get_agent_runs(world_seed: int) -> list[dict[str, Any]]:
+    init_db()
+    with _connect() as conn:
+        rows = conn.execute(
+            """SELECT agent_name, started_at, nodes_visited
+               FROM agent_runs WHERE world_seed = ?
+               ORDER BY started_at DESC""",
+            (world_seed,),
+        ).fetchall()
+        return [{"agent_name": r[0], "started_at": r[1], "nodes_visited": r[2]} for r in rows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.backends.legacy:BuildBackend"
+
+[project]
+name = "hello-nested-worlds-adventure"
+version = "0.1.0"
+description = "A nested multiverse simulation engine with agent traversal and puzzles"
+requires-python = ">=3.11"
+dependencies = [
+    "anthropic>=0.40.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]


### PR DESCRIPTION
## Summary
This PR adds a complete persistence layer for saving and retrieving world generation data, agent traversal logs, and puzzle results. It also introduces a consciousness module for in-character node interactions via Claude AI, and extends the CLI with new commands for viewing history and speaking to nodes.

## Key Changes

**Persistence Layer** (`persistence/__init__.py`)
- New SQLite-based persistence module with three main tables: `worlds`, `agent_runs`, and `puzzle_results`
- Functions to save world generation parameters, agent traversal events, and puzzle attempt results
- Query functions to list saved worlds and retrieve agent runs for a given world seed
- Database stored in `~/.nested-worlds/worlds.db` with WAL mode enabled for concurrent access

**Consciousness Module** (`consciousness/__init__.py`)
- New module for in-character node interactions using Claude Opus 4.7
- Lazy-loads Anthropic client to avoid requiring the dependency unless the feature is used
- Uses prompt caching for the system preamble to optimize token usage across multiple node interactions
- `speak()` function sends messages to nodes and returns in-character responses
- `describe()` convenience function for node self-introductions

**CLI Enhancements** (`main.py`)
- `world` command now saves generated worlds with node counts and hierarchy depth
- `agent` command persists traversal logs with event details (node, level, state, action)
- `puzzles` command saves puzzle results with attempt counts
- New `history` command displays saved worlds and associated agent runs in a formatted table
- New `speak` command allows interactive conversations with nodes in the world hierarchy
- Added helper functions `_count_nodes()` and `_find_node()` for world introspection

**Type Safety & Code Quality**
- Added comprehensive type hints throughout (`main.py`, `agents/agent.py`, `multiverse/node.py`)
- Removed unnecessary comments and improved code organization
- Added `from __future__ import annotations` for forward compatibility

**Node Improvements** (`multiverse/node.py`)
- Each `SpatialNode` now has a unique UUID (`id` field) for reliable tracking across persistence
- Agent traversal now tracks node IDs instead of names to handle duplicate node names
- Improved type annotations for all methods and attributes

**Agent Refactoring** (`agents/agent.py`)
- Separated traversal logic into `traverse()` (public API) and `_traverse()` (recursive implementation)
- Added state reset in `traverse()` to enable multiple runs with the same agent instance
- Changed visited tracking from node names to node IDs
- Added depth limit (500) to prevent stack overflow on malformed hierarchies
- Improved type hints and docstrings

**Project Configuration** (`pyproject.toml`)
- Added project metadata and build configuration
- Declared `anthropic>=0.40.0` as a dependency
- Added pytest as optional dev dependency

## Notable Implementation Details

- The persistence module calls `init_db()` before each operation to ensure tables exist, allowing lazy initialization
- Agent events are serialized to JSON for storage, preserving the full traversal history
- The consciousness module uses Anthropic's prompt caching feature on the system preamble to reduce token costs
- Node IDs are UUIDs to ensure uniqueness even when the same world is generated multiple times
- The `speak` command gracefully handles missing nodes and provides helpful error messages

https://claude.ai/code/session_01N3rm2wTbLnTaXBuwsxbuhY