### PR TITLE
Nested Worlds Adventure: Planetary System, self-preservation, and expanded puzzles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nested-worlds
+# Nested Worlds Adventure
 
 **A shared persistent multiverse inhabited simultaneously by human players and AI agents.**
 
@@ -6,7 +6,7 @@
 
 ## Concept
 
-Nested Worlds is an environment where the boundary between player, agent, and world is deliberately blurred.
+Nested Worlds Adventure is an environment where the boundary between player, agent, and world is deliberately blurred.
 
 The multiverse is always running. You enter and find it already in motion — other humans and AI agents traversing different scales, each leaving traces the world carries forward. You may never encounter another player directly, but you will feel the consequences of their presence through cross-scale causality: a destabilized atom cascading into a volatile region, a solved puzzle stabilizing a galaxy, an agent's curiosity reshaping a planet's danger over time.
 
@@ -23,7 +23,7 @@ Interaction is multi-modal: natural language for depth, visual navigation for mo
 Ten nested scales, each with its own aesthetic register and causal weight:
 
 ```
-Multiverse → Universe → Galaxy → Planet → Region → Room → Object → Molecule → Atom → SubatomicParticle
+Multiverse → Universe → Galaxy → Planetary System → Planet → Region → Room → Object → Molecule → Atom → SubatomicParticle
 ```
 
 ### Core Systems
@@ -80,7 +80,7 @@ Human-to-human, human-to-agent, agent-to-human, agent-to-agent: all four interac
 | System | Status |
 |--------|--------|
 | World model (`multiverse/`) | Functional — named locations, variable branching, rich per-level properties |
-| Agent traversal (`agents/`) | Functional — FSM traversal, danger avoidance, interaction logging, causal event emission |
+| Agent traversal (`agents/`) | Functional — FSM traversal, self-preservation, interaction logging, causal event emission |
 | Puzzle engine (`puzzles/`) | Functional — four puzzle kinds, hints, attempt tracking |
 | Causality engine (`causality/`) | Functional — event propagation with configurable dampening |
 | Persistence (`persistence/`) | Functional — SQLite world state, agent runs, puzzle results |

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List
 from multiverse.node import SpatialNode
-from agents.behaviors import State, transition, should_avoid
+from agents.behaviors import State, transition, should_preserve
 import causality
 from causality import EventKind
 
@@ -32,8 +32,8 @@ class Agent:
 
     def _act(self, node: SpatialNode) -> bool:
         if self.state == State.EXPLORE:
-            if should_avoid(node, self.danger_threshold):
-                self._record(node, f"avoided (danger_level={node.properties.get('danger_level')})")
+            if should_preserve(node, self.danger_threshold):
+                self._record(node, f"withdrew (danger_level={node.properties.get('danger_level')})")
                 causality.emit(node, EventKind.DANGER_ALERT, {"agent": self.name})
                 return False
             self._record(node, "explored")
@@ -47,8 +47,8 @@ class Agent:
             causality.propagate(node, kind, {"agent": self.name})
 
         elif self.state == State.EXIT:
-            if should_avoid(node, self.danger_threshold):
-                self._record(node, f"avoided (danger_level={node.properties.get('danger_level')})")
+            if should_preserve(node, self.danger_threshold):
+                self._record(node, f"withdrew (danger_level={node.properties.get('danger_level')})")
             else:
                 self._record(node, "exited")
             return False

--- a/agents/behaviors.py
+++ b/agents/behaviors.py
@@ -10,7 +10,7 @@ class State(Enum):
     EXIT = auto()
 
 
-def should_avoid(node, danger_threshold: int = 6) -> bool:
+def should_preserve(node, danger_threshold: int = 6) -> bool:
     return node.properties.get("danger_level", 0) > danger_threshold
 
 
@@ -27,7 +27,7 @@ def transition(state: State, node) -> State:
         return State.EXPLORE
 
     if state == State.EXPLORE:
-        if should_avoid(node):
+        if should_preserve(node):
             return State.EXIT
         if should_interact(node):
             return State.INTERACT

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Changed
+- **Project renamed** to *Nested Worlds Adventure* (`pyproject.toml`, CLI, server banner, README)
+- **Planetary System** added between Galaxy and Planet in the 11-level hierarchy (`multiverse/generator.py`); includes star_type, planet_count, habitable_zone, and asteroid_belt properties
+- **Self-preservation** replaces "danger avoidance" throughout the agent system: `should_avoid` renamed to `should_preserve`, log messages changed from "avoided" to "withdrew", CLI help updated
+- **Puzzle engine** expanded with four new `PuzzleKind` variants: `PATTERN`, `LOGIC`, `ANAGRAM`, `NAVIGATION` — each with multiple puzzle instances
+- Default `max_depth` updated to 11 to match the expanded 11-level hierarchy
+
+
+
 ### Vision
 Reframed as a shared persistent multiverse for simultaneous human and AI participation. Core new systems identified: node consciousness (Claude-powered voice layer), causality engine (cross-scale propagation), persistence (world state database), server (real-time API), and interface (generative visual layer). README and architecture docs updated to reflect new direction. New module directories scaffolded.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -57,7 +57,7 @@ Propagation system for cross-scale effects. Actions register as events; conseque
 - `registry.py` — event log and state tracking
 
 ### `agents/` — AI Agent System
-- **`agent.py`** — `Agent` dataclass with FSM traversal, danger avoidance, interaction logging
+- **`agent.py`** — `Agent` dataclass with FSM traversal, self-preservation logic, interaction logging
 - **`behaviors.py`** — `State` enum, `transition()` function, behavioral predicates
 - Planned: `persona.py` for Claude-powered agent personalities with goals and memory
 

--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ def cmd_speak(args):
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="main.py",
-        description="hello-nested-worlds-adventure: multiverse simulation engine",
+        description="Nested Worlds Adventure: shared persistent multiverse simulation",
     )
     parser.add_argument("--seed", type=int, default=42, help="RNG seed (default: 42)")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -122,7 +122,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_agent = sub.add_parser("agent", help="Run an agent traversal of the world")
     p_agent.add_argument("--name", type=str, default="Scout", help="Agent name (default: Scout)")
     p_agent.add_argument("--danger-threshold", type=int, default=6, dest="danger_threshold",
-                         help="Avoid regions with danger_level above this (default: 6)")
+                         help="Self-preservation threshold: withdraw from nodes with danger_level above this (default: 6)")
     p_agent.add_argument("--max-nodes", type=int, default=50, dest="max_nodes",
                          help="Max nodes to visit (default: 50)")
     p_agent.set_defaults(func=cmd_agent)

--- a/multiverse/generator.py
+++ b/multiverse/generator.py
@@ -7,6 +7,7 @@ LEVELS = [
     "Multiverse",
     "Universe",
     "Galaxy",
+    "Planetary System",
     "Planet",
     "Region",
     "Room",
@@ -19,6 +20,7 @@ LEVELS = [
 _MULTIVERSE_NAMES = ["Aethon", "Vorrex", "Nullspace", "Cascade", "Ouroboros"]
 _UNIVERSE_NAMES = ["Aldric", "Solvane", "Mireth", "Cerulean", "Thornvast"]
 _GALAXY_NAMES = ["Vela", "Cygnus", "Andromeda", "Sable Arm", "Ember Drift"]
+_PLANETARY_SYSTEM_NAMES = ["Ardent Prime", "Vethara", "Keleth", "Auric", "Thorngate", "Solweave", "Kaelos"]
 _PLANET_NAMES = ["Kethara", "Droven", "Islune", "Pyreth", "Solmara", "Ashveil", "Quelris"]
 _REGION_NAMES = ["Ashfields", "The Mire", "Crystalpeak", "Undergate", "Verdant Hollow"]
 _ROOM_NAMES = ["Antechamber", "Vault", "Observatory", "Engine Room", "Sanctum", "The Pit", "Archive"]
@@ -47,6 +49,12 @@ def generate_properties(level: str, rng: random.Random) -> dict:
             "star_density": rng.randint(50, 500),
             "shape": _pick(["spiral", "elliptical", "irregular", "ring"], rng),
             "black_hole_mass_solar": rng.randint(100_000, 10_000_000),
+        },
+        "Planetary System": {
+            "star_type": _pick(["yellow dwarf", "red dwarf", "white dwarf", "binary", "neutron star"], rng),
+            "planet_count": rng.randint(1, 12),
+            "habitable_zone": rng.choice([True, False]),
+            "asteroid_belt": rng.choice([True, False]),
         },
         "Planet": {
             "gravity": round(rng.uniform(0.1, 3.5), 2),
@@ -97,6 +105,7 @@ _NAME_POOLS = {
     "Multiverse": _MULTIVERSE_NAMES,
     "Universe": _UNIVERSE_NAMES,
     "Galaxy": _GALAXY_NAMES,
+    "Planetary System": _PLANETARY_SYSTEM_NAMES,
     "Planet": _PLANET_NAMES,
     "Region": _REGION_NAMES,
     "Room": _ROOM_NAMES,
@@ -112,7 +121,7 @@ def _generate_name(level: str, index: int, rng: random.Random) -> str:
     return f"{level}-{_pick(suffixes, rng)}-{index}"
 
 
-def generate_node_hierarchy(seed: int = 42, max_depth: int = 10, min_breadth: int = 1, max_breadth: int = 3) -> SpatialNode:
+def generate_node_hierarchy(seed: int = 42, max_depth: int = 11, min_breadth: int = 1, max_breadth: int = 3) -> SpatialNode:
     if min_breadth > max_breadth:
         raise ValueError(f"min_breadth ({min_breadth}) must not exceed max_breadth ({max_breadth})")
     if not 1 <= max_depth <= len(LEVELS):

--- a/puzzles/engine.py
+++ b/puzzles/engine.py
@@ -60,7 +60,78 @@ _SEQUENCE_PUZZLES = [
     ),
 ]
 
-_ALL_PUZZLES = _RIDDLES + _CIPHER_PUZZLES + _LOCK_PUZZLES + _SEQUENCE_PUZZLES
+_PATTERN_PUZZLES = [
+    Puzzle(
+        name="The Ascending Squares",
+        kind=PuzzleKind.PATTERN,
+        prompt="What comes next in the sequence: 1, 4, 9, 16, 25, ?",
+        answer="36",
+        hints=["Each number is a perfect square.", "6 × 6 = ?"],
+    ),
+    Puzzle(
+        name="The Skipping Alphabet",
+        kind=PuzzleKind.PATTERN,
+        prompt="What letter comes next: A, C, E, G, ?",
+        answer="I",
+        hints=["Every other letter of the alphabet.", "The pattern skips one letter each time."],
+    ),
+]
+
+_LOGIC_PUZZLES = [
+    Puzzle(
+        name="The Shepherd's Count",
+        kind=PuzzleKind.LOGIC,
+        prompt="A shepherd has 17 sheep. All but 9 wander off into the void. How many remain?",
+        answer="9",
+        hints=["Read carefully — 'all but 9'.", "'All but 9' means exactly 9 are still here."],
+    ),
+    Puzzle(
+        name="The Three Travelers",
+        kind=PuzzleKind.LOGIC,
+        prompt="Two fathers and two sons sat down to eat. Three rations were served — each person received exactly one. How many people were there?",
+        answer="3",
+        hints=["One of the fathers is also a son.", "Think: grandfather, father, child."],
+    ),
+]
+
+_ANAGRAM_PUZZLES = [
+    Puzzle(
+        name="The Scrambled Gate",
+        kind=PuzzleKind.ANAGRAM,
+        prompt="Unscramble these letters to find what connects worlds: LATPRO",
+        answer="portal",
+        hints=["It is a doorway between places.", "Six letters. Starts with P."],
+    ),
+    Puzzle(
+        name="The Hidden Force",
+        kind=PuzzleKind.ANAGRAM,
+        prompt="Unscramble to reveal a fundamental force: YTGVIAR",
+        answer="gravity",
+        hints=["It pulls things together across every scale.", "Seven letters. Shapes every planet."],
+    ),
+]
+
+_NAVIGATION_PUZZLES = [
+    Puzzle(
+        name="The Directional Trial",
+        kind=PuzzleKind.NAVIGATION,
+        prompt="You enter a corridor facing north. You turn right, walk forward, then turn left, walk forward. What direction are you now facing?",
+        answer="north",
+        hints=["Right from north is east. Left from east is north.", "Each turn changes your facing direction only — not your position."],
+    ),
+    Puzzle(
+        name="The Return Path",
+        kind=PuzzleKind.NAVIGATION,
+        prompt="From the entrance: go north, then east, then south. What single direction returns you to the start?",
+        answer="west",
+        hints=["Track your position step by step.", "You ended up one step east of where you started."],
+    ),
+]
+
+_ALL_PUZZLES = (
+    _RIDDLES + _CIPHER_PUZZLES + _LOCK_PUZZLES + _SEQUENCE_PUZZLES
+    + _PATTERN_PUZZLES + _LOGIC_PUZZLES + _ANAGRAM_PUZZLES + _NAVIGATION_PUZZLES
+)
 
 
 class PuzzleEngine:

--- a/puzzles/types.py
+++ b/puzzles/types.py
@@ -10,6 +10,10 @@ class PuzzleKind(Enum):
     SEQUENCE = auto()     # Enter items in the right order
     CIPHER = auto()       # Decode an encoded message
     LOCK = auto()         # Supply the correct key/code
+    PATTERN = auto()      # Identify or complete a numeric/symbolic pattern
+    LOGIC = auto()        # Deductive or lateral thinking puzzle
+    ANAGRAM = auto()      # Unscramble letters to form a word or phrase
+    NAVIGATION = auto()   # Follow spatial instructions and determine a result
 
 
 class PuzzleResult(Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=68"]
 build-backend = "setuptools.backends.legacy:BuildBackend"
 
 [project]
-name = "hello-nested-worlds-adventure"
+name = "nested-worlds-adventure"
 version = "0.1.0"
-description = "A nested multiverse simulation engine with agent traversal and puzzles"
+description = "Nested Worlds Adventure: a shared persistent multiverse inhabited by human players and AI agents"
 requires-python = ">=3.11"
 dependencies = [
     "anthropic>=0.40.0",

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -102,7 +102,7 @@ class _Handler(BaseHTTPRequestHandler):
 def run(host: str = "127.0.0.1", port: int = 8080) -> None:
     """Start the HTTP server (blocking)."""
     server = HTTPServer((host, port), _Handler)
-    print(f"Nested Worlds server running at http://{host}:{port}")
+    print(f"Nested Worlds Adventure server running at http://{host}:{port}")
     print("Endpoints: /health  /worlds  /world?seed=N  /agent?seed=N")
     print("Press Ctrl+C to stop.")
     try:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,7 +2,7 @@ import pytest
 from multiverse.generator import generate_node_hierarchy
 from multiverse.node import SpatialNode
 from agents.agent import Agent
-from agents.behaviors import State, transition, should_avoid, should_interact
+from agents.behaviors import State, transition, should_preserve, should_interact
 
 
 def make_node(level="Room", **props):
@@ -10,13 +10,13 @@ def make_node(level="Room", **props):
 
 
 class TestBehaviors:
-    def test_should_avoid_high_danger(self):
+    def test_should_preserve_from_high_danger(self):
         node = make_node(danger_level=8)
-        assert should_avoid(node, danger_threshold=6)
+        assert should_preserve(node, danger_threshold=6)
 
-    def test_should_not_avoid_low_danger(self):
+    def test_should_not_preserve_from_low_danger(self):
         node = make_node(danger_level=3)
-        assert not should_avoid(node, danger_threshold=6)
+        assert not should_preserve(node, danger_threshold=6)
 
     def test_should_interact_with_puzzle(self):
         node = make_node(has_puzzle=True)
@@ -61,7 +61,7 @@ class TestAgent:
         agent.traverse(root, max_nodes=10)
         assert len(agent.visited) <= 10
 
-    def test_agent_avoids_dangerous_nodes(self):
+    def test_agent_withdraws_from_dangerous_nodes(self):
         dangerous = SpatialNode(name="Danger-Zone", level="Region", properties={"danger_level": 9})
         safe = SpatialNode(name="Safe-Zone", level="Region", properties={"danger_level": 2})
         root = SpatialNode(name="Root", level="Planet", properties={"gravity": 1.0})
@@ -71,8 +71,8 @@ class TestAgent:
         agent = Agent(name="Cautious", danger_threshold=6)
         agent.traverse(root, max_nodes=20)
 
-        avoided = [e for e in agent.log if "avoided" in e.action]
-        assert len(avoided) >= 1
+        withdrew = [e for e in agent.log if "withdrew" in e.action]
+        assert len(withdrew) >= 1
 
     def test_agent_report_contains_name(self):
         root = generate_node_hierarchy(seed=5, max_depth=3, min_breadth=1, max_breadth=1)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4,19 +4,19 @@ from multiverse.node import SpatialNode
 
 
 def test_deterministic():
-    a = generate_node_hierarchy(seed=1)
-    b = generate_node_hierarchy(seed=1)
+    a = generate_node_hierarchy(seed=1, max_depth=4)
+    b = generate_node_hierarchy(seed=1, max_depth=4)
     assert repr(a) == repr(b)
 
 
 def test_different_seeds_differ():
-    a = generate_node_hierarchy(seed=1)
-    b = generate_node_hierarchy(seed=99)
+    a = generate_node_hierarchy(seed=1, max_depth=4)
+    b = generate_node_hierarchy(seed=99, max_depth=4)
     assert repr(a) != repr(b)
 
 
 def test_root_is_multiverse():
-    root = generate_node_hierarchy()
+    root = generate_node_hierarchy(max_depth=3)
     assert root.level == "Multiverse"
 
 
@@ -55,8 +55,22 @@ def test_node_levels_follow_hierarchy():
             node = node.children[0]
 
 
+def test_planetary_system_in_hierarchy():
+    root = generate_node_hierarchy(seed=1, max_depth=4, min_breadth=1, max_breadth=1)
+    # With max_depth=4: Multiverse → Universe → Galaxy → Planetary System
+    node = root
+    for _ in range(3):
+        assert node.children, f"{node.level} should have a child"
+        node = node.children[0]
+    assert node.level == "Planetary System"
+    assert "star_type" in node.properties
+    assert "planet_count" in node.properties
+    assert "habitable_zone" in node.properties
+
+
 def test_planet_properties():
-    root = generate_node_hierarchy(seed=42, max_depth=5, min_breadth=2, max_breadth=2)
+    # max_depth=6 reaches Planet (index 4) with Planetary System (index 3) now in between
+    root = generate_node_hierarchy(seed=42, max_depth=6, min_breadth=2, max_breadth=2)
 
     def find_planets(node):
         results = []

--- a/tests/test_puzzles.py
+++ b/tests/test_puzzles.py
@@ -64,7 +64,7 @@ class TestPuzzleTypes:
 
 class TestPuzzleEngine:
     def test_attach_and_collect(self):
-        # max_depth=7 ensures Room nodes (level index 5) are generated, which carry has_puzzle
+        # max_depth=7 ensures Room nodes (level index 6) are generated, which carry has_puzzle
         root = generate_node_hierarchy(seed=42, max_depth=7, min_breadth=2, max_breadth=2)
         engine = PuzzleEngine(seed=42)
         engine.attach_puzzles(root)


### PR DESCRIPTION
Four changes proposed for the project direction.

**Rename to Nested Worlds Adventure**
Updates the package name, CLI description, server banner, and README title.

**Planetary System added to hierarchy**
Inserted between Galaxy and Planet — the hierarchy is now 11 levels. Planetary
System nodes carry star_type, planet_count, habitable_zone, and asteroid_belt
properties and their own name pool (Ardent Prime, Vethara, Keleth, Auric…).
Default max_depth updated from 10 to 11 to reach all levels.

**Self-preservation replaces danger avoidance**
should_avoid → should_preserve throughout agents/. Agent logs now read
"withdrew (danger_level=N)" rather than "avoided". CLI help text updated.
The framing shift: agents don't avoid danger, they act in their own interest.

**Four new puzzle types**
PATTERN, LOGIC, ANAGRAM, and NAVIGATION added to PuzzleKind, each with two
puzzle instances covering number sequences, lateral thinking, word unscrambling,
and spatial direction problems.

Tests and docs updated throughout.