### PR TITLE
Fix ambient mode: dampen event strength by traversal depth

### DIFF
--- a/interface/__init__.py
+++ b/interface/__init__.py
@@ -74,17 +74,33 @@ def _print_map(node: SpatialNode, prefix: str = "", is_last: bool = True,
         print(f"{child_prefix}└─ {_DIM}… ({count} child{'ren' if count != 1 else ''}){_RESET}")
 
 
+def _build_depth_map(node: SpatialNode, depth: int = 0, result: dict | None = None) -> dict[str, int]:
+    if result is None:
+        result = {}
+    result[node.id] = depth
+    for child in node.children:
+        _build_depth_map(child, depth + 1, result)
+    return result
+
+
+_AMBIENT_DAMPENING = 0.6
+
+
 def _ambient_mode(node: SpatialNode) -> None:
     print(f"\n{_DIM}Entering ambient observation. An agent moves through the world…{_RESET}\n")
     print(f"  {'Node':<30}  {'Event':<22}  {'Strength'}")
     print(f"  {_DIM}{'─'*30}  {'─'*22}  {'─'*20}{_RESET}")
 
+    depth_map = _build_depth_map(node)
+
     def _handler(n: SpatialNode, event: causality.CausalEvent) -> None:
         style = _LEVEL_STYLES.get(n.level, "")
         kind = event.kind.name.replace("_", " ").lower()
-        filled = max(1, round(event.strength * 20))
+        depth = depth_map.get(n.id, 0)
+        strength = _AMBIENT_DAMPENING ** depth
+        filled = max(1, round(strength * 20))
         bar = "█" * filled + _DIM + "░" * (20 - filled) + _RESET
-        print(f"  {style}{n.name:<30}{_RESET}  {kind:<22}  {bar}  {event.strength:.2f}")
+        print(f"  {style}{n.name:<30}{_RESET}  {kind:<22}  {bar}  {strength:.2f}")
         time.sleep(0.04)
 
     causality.register_handler(_handler)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -14,7 +14,9 @@ from interface import (
     _print_breadcrumb,
     _descend,
     _ambient_mode,
+    _build_depth_map,
     _play_puzzle,
+    _AMBIENT_DAMPENING,
 )
 
 
@@ -115,11 +117,35 @@ class TestNavigation:
         assert len(stack) == 1
 
 
+class TestDepthMap:
+    def test_root_is_depth_zero(self):
+        root = make_tree()
+        dm = _build_depth_map(root)
+        assert dm[root.id] == 0
+
+    def test_child_is_depth_one(self):
+        root = make_tree()
+        dm = _build_depth_map(root)
+        assert dm[root.children[0].id] == 1
+
+    def test_grandchild_is_depth_two(self):
+        root = make_tree()
+        grandchild = root.children[0].children[0]
+        dm = _build_depth_map(root)
+        assert dm[grandchild.id] == 2
+
+    def test_all_nodes_present(self):
+        root = make_tree()
+        dm = _build_depth_map(root)
+        assert len(dm) == 3  # root + galaxy + planet
+
+
 class TestAmbientMode:
     def test_ambient_registers_and_clears_handler(self):
         root = make_tree()
         with patch("builtins.input", return_value=""):
-            _ambient_mode(root)
+            with patch("time.sleep"):
+                _ambient_mode(root)
         assert causality._handlers == []
 
     def test_ambient_fires_causal_events(self):
@@ -146,6 +172,16 @@ class TestAmbientMode:
             with patch("time.sleep"):
                 _ambient_mode(root)
         assert causality.get_log() == []
+
+    def test_ambient_strength_dampens_with_depth(self, capsys):
+        root = make_tree()
+        with patch("builtins.input", return_value=""):
+            with patch("time.sleep"):
+                _ambient_mode(root)
+        out = capsys.readouterr().out
+        # Root should show 1.00, deeper nodes less
+        assert "1.00" in out
+        assert f"{_AMBIENT_DAMPENING:.2f}" in out
 
 
 class TestPuzzleMode:


### PR DESCRIPTION
## Summary

- Ambient `observe` mode was displaying all events at 1.00 strength because the agent emits via `causality.emit()` (no propagation)
- Pre-builds a depth map from the observation origin before the agent runs
- Display strength is now computed as `0.6 ** depth`, so events visually attenuate as the agent moves deeper into the hierarchy

## Test plan

- [ ] Run `observe` from the Multiverse root — confirm strength bars shrink with each level (1.00 → 0.60 → 0.36 → …)
- [ ] Run `observe` from a leaf-adjacent node — confirm root shows 1.00
- [ ] `pytest tests/` — all 83 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01VD7GxjxnN98r8HqbMZvsuT)_