### PR TITLE
Multiplayer sharing beta: WebSocket backend + persistent world mutations

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,7 +150,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_play.set_defaults(func=cmd_play)
 
     p_serve = sub.add_parser("serve", help="Start the REST API server")
-    p_serve.add_argument("--host", type=str, default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
+    p_serve.add_argument("--host", type=str, default="0.0.0.0", help="Bind host (default: 0.0.0.0)")
     p_serve.add_argument("--port", type=int, default=8080, help="Bind port (default: 8080)")
     p_serve.set_defaults(func=cmd_serve)
 

--- a/persistence/__init__.py
+++ b/persistence/__init__.py
@@ -46,6 +46,16 @@ def init_db() -> None:
                 attempts    INTEGER NOT NULL,
                 recorded_at TEXT NOT NULL DEFAULT (datetime('now'))
             );
+
+            CREATE TABLE IF NOT EXISTS world_mutations (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                world_seed    INTEGER NOT NULL,
+                node_name     TEXT NOT NULL,
+                mutation_type TEXT NOT NULL,
+                player_name   TEXT,
+                data          TEXT,
+                recorded_at   TEXT NOT NULL DEFAULT (datetime('now'))
+            );
         """)
 
 
@@ -87,6 +97,31 @@ def list_worlds() -> list[dict[str, Any]]:
             "SELECT seed, created_at, node_count, max_depth FROM worlds ORDER BY created_at DESC"
         ).fetchall()
         return [{"seed": r[0], "created_at": r[1], "node_count": r[2], "max_depth": r[3]} for r in rows]
+
+
+def record_mutation(world_seed: int, node_name: str, mutation_type: str,
+                    player_name: str | None, data: dict) -> None:
+    init_db()
+    with _connect() as conn:
+        conn.execute(
+            """INSERT INTO world_mutations (world_seed, node_name, mutation_type, player_name, data)
+               VALUES (?, ?, ?, ?, ?)""",
+            (world_seed, node_name, mutation_type, player_name, json.dumps(data)),
+        )
+
+
+def get_mutations(world_seed: int, limit: int = 50) -> list[dict[str, Any]]:
+    init_db()
+    with _connect() as conn:
+        rows = conn.execute(
+            """SELECT node_name, mutation_type, player_name, data, recorded_at
+               FROM world_mutations WHERE world_seed = ?
+               ORDER BY recorded_at DESC LIMIT ?""",
+            (world_seed, limit),
+        ).fetchall()
+        return [{"node": r[0], "type": r[1], "player": r[2],
+                 "data": json.loads(r[3]) if r[3] else {}, "at": r[4]}
+                for r in rows]
 
 
 def get_agent_runs(world_seed: int) -> list[dict[str, Any]]:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
+import struct
 import threading
+import uuid
+from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from socketserver import ThreadingMixIn
@@ -17,6 +22,113 @@ import persistence
 _STATIC_DIR = Path(__file__).parent.parent / "static"
 _OBSERVE_LOCK = threading.Lock()
 _DAMPENING = 0.6
+_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+
+# ── WebSocket protocol ─────────────────────────────────────────────────────
+
+def _ws_recvall(sock, n: int) -> bytes:
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionResetError("WebSocket connection closed")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def _ws_recv(sock) -> bytes | None:
+    """Return next data-frame payload, b'' for control frames, None on close."""
+    header = _ws_recvall(sock, 2)
+    b0, b1 = header[0], header[1]
+    opcode = b0 & 0x0F
+    masked = bool(b1 & 0x80)
+    length = b1 & 0x7F
+    if length == 126:
+        length = struct.unpack(">H", _ws_recvall(sock, 2))[0]
+    elif length == 127:
+        length = struct.unpack(">Q", _ws_recvall(sock, 8))[0]
+    mask_key = _ws_recvall(sock, 4) if masked else b""
+    payload = bytearray(_ws_recvall(sock, length))
+    if masked:
+        for i in range(len(payload)):
+            payload[i] ^= mask_key[i % 4]
+    if opcode == 0x8:  # close frame
+        return None
+    if opcode in (0x9, 0xA):  # ping / pong — discard payload
+        return b""
+    return bytes(payload)
+
+
+def _ws_send(sock, data: str | bytes) -> None:
+    if isinstance(data, str):
+        data = data.encode()
+    n = len(data)
+    if n <= 125:
+        frame = bytes([0x81, n]) + data
+    elif n <= 65535:
+        frame = struct.pack(">BBH", 0x81, 126, n) + data
+    else:
+        frame = struct.pack(">BBQ", 0x81, 127, n) + data
+    sock.sendall(frame)
+
+
+# ── Multiplayer rooms ──────────────────────────────────────────────────────
+
+@dataclass
+class _Player:
+    name: str
+    seed: int
+    current_node: str
+    session_id: str
+    sock: object
+    _lock: threading.Lock = field(default_factory=threading.Lock, compare=False, repr=False)
+
+    def send(self, msg: dict) -> bool:
+        try:
+            with self._lock:
+                _ws_send(self.sock, json.dumps(msg))
+            return True
+        except OSError:
+            return False
+
+
+@dataclass
+class _Room:
+    players: dict = field(default_factory=dict)   # session_id → _Player
+    lock: threading.Lock = field(default_factory=threading.Lock, compare=False, repr=False)
+
+
+_rooms: dict[int, _Room] = {}
+_rooms_lock = threading.Lock()
+
+
+def _get_room(seed: int) -> _Room:
+    with _rooms_lock:
+        if seed not in _rooms:
+            _rooms[seed] = _Room()
+        return _rooms[seed]
+
+
+def _broadcast(room: _Room, msg: dict, exclude: str | None = None) -> None:
+    with room.lock:
+        targets = list(room.players.items())
+    failed = []
+    for sid, player in targets:
+        if sid == exclude:
+            continue
+        if not player.send(msg):
+            failed.append(sid)
+    if failed:
+        with room.lock:
+            for sid in failed:
+                room.players.pop(sid, None)
+
+
+def _room_snapshot(room: _Room) -> list[dict]:
+    with room.lock:
+        return [{"name": p.name, "node": p.current_node, "session_id": p.session_id}
+                for p in room.players.values()]
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────
@@ -120,6 +232,21 @@ class _Handler(BaseHTTPRequestHandler):
         elif path == "/worlds":
             self._send_json(persistence.list_worlds())
 
+        elif path == "/players":
+            try:
+                seed = int(param("seed", "42"))
+            except ValueError:
+                return self._send_error("invalid seed")
+            room = _get_room(seed)
+            self._send_json({"players": _room_snapshot(room)})
+
+        elif path == "/history":
+            try:
+                seed = int(param("seed", "42"))
+            except ValueError:
+                return self._send_error("invalid seed")
+            self._send_json({"mutations": persistence.get_mutations(seed)})
+
         elif path == "/world":
             try:
                 seed  = int(param("seed",        "42"))
@@ -162,6 +289,9 @@ class _Handler(BaseHTTPRequestHandler):
         elif path == "/puzzle":
             self._do_puzzle(qs)
 
+        elif path == "/ws":
+            self._do_ws(qs)
+
         else:
             self._send_error("not found", 404)
 
@@ -197,11 +327,76 @@ class _Handler(BaseHTTPRequestHandler):
         else:
             self._send_error("not found", 404)
 
+    # ── WebSocket ──
+
+    def _do_ws(self, qs: dict) -> None:
+        key = self.headers.get("Sec-WebSocket-Key", "")
+        if not key:
+            return self._send_error("WebSocket upgrade required", 400)
+
+        try:
+            seed = int(qs.get("seed", ["42"])[0])
+            name = (qs.get("name", ["Anonymous"])[0] or "Anonymous")[:32]
+        except (ValueError, IndexError):
+            return self._send_error("invalid params", 400)
+
+        accept = base64.b64encode(
+            hashlib.sha1((key + _WS_GUID).encode()).digest()
+        ).decode()
+        self.send_response(101, "Switching Protocols")
+        self.send_header("Upgrade", "websocket")
+        self.send_header("Connection", "Upgrade")
+        self.send_header("Sec-WebSocket-Accept", accept)
+        self.end_headers()
+        self.wfile.flush()
+
+        sock = self.connection
+        session_id = uuid.uuid4().hex[:8]
+        player = _Player(name=name, seed=seed, current_node="", session_id=session_id, sock=sock)
+
+        room = _get_room(seed)
+        with room.lock:
+            room.players[session_id] = player
+
+        player.send({"type": "welcome", "session_id": session_id,
+                     "players": _room_snapshot(room)})
+        _broadcast(room, {"type": "player_join", "name": name, "session_id": session_id},
+                   exclude=session_id)
+
+        try:
+            while True:
+                payload = _ws_recv(sock)
+                if payload is None:
+                    break
+                if not payload:
+                    continue  # control frame
+                try:
+                    msg = json.loads(payload)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                msg_type = msg.get("type")
+                if msg_type == "move":
+                    node_name = str(msg.get("node", ""))[:64]
+                    with room.lock:
+                        player.current_node = node_name
+                    _broadcast(room, {"type": "player_move", "name": name,
+                                      "node": node_name, "session_id": session_id},
+                               exclude=session_id)
+                elif msg_type == "ping":
+                    player.send({"type": "pong"})
+        except (OSError, ConnectionResetError, BrokenPipeError):
+            pass
+        finally:
+            with room.lock:
+                room.players.pop(session_id, None)
+            _broadcast(room, {"type": "player_leave", "name": name,
+                               "session_id": session_id})
+
     # ── Observe (SSE) ──
 
     def _do_observe(self, qs: dict) -> None:
         try:
-            root, *_ = _rebuild(qs)
+            root, seed, *_ = _rebuild(qs)
         except (ValueError, KeyError) as exc:
             return self._send_error(str(exc))
 
@@ -237,8 +432,11 @@ class _Handler(BaseHTTPRequestHandler):
             try:
                 agent = Agent(name="Observer", danger_threshold=7)
                 agent.traverse(target, max_nodes=40)
-                self._sse_event({"done": True,
-                                 "nodes_visited": len(agent.visited)})
+                nodes_visited = len(agent.visited)
+                self._sse_event({"done": True, "nodes_visited": nodes_visited})
+                room = _get_room(seed)
+                _broadcast(room, {"type": "agent_done", "node": target.name,
+                                   "nodes_visited": nodes_visited})
             except (BrokenPipeError, ConnectionResetError):
                 pass
             finally:
@@ -304,6 +502,14 @@ class _Handler(BaseHTTPRequestHandler):
                    if not correct and not failed and attempt <= len(p.hints)
                    else None)
 
+        if correct:
+            effective_node = node_name or target.name
+            persistence.record_mutation(seed, effective_node, "PUZZLE_SOLVED",
+                                        None, {"puzzle": p.name})
+            room = _get_room(seed)
+            _broadcast(room, {"type": "puzzle_solved", "node": effective_node,
+                               "puzzle": p.name})
+
         self._send_json({
             "correct":        correct,
             "result":         "SOLVED" if correct else ("FAILED" if failed else "UNSOLVED"),
@@ -322,7 +528,13 @@ class _ThreadedServer(ThreadingMixIn, HTTPServer):
 
 def run(host: str = "127.0.0.1", port: int = 8080) -> None:
     server = _ThreadedServer((host, port), _Handler)
-    print(f"Nested Worlds Adventure  →  http://{host}:{port}")
+    display = f"http://localhost:{port}" if host in ("0.0.0.0", "") else f"http://{host}:{port}"
+    print(f"Nested Worlds Adventure  →  {display}")
+    print(f"Multiplayer WebSocket   →  ws://localhost:{port}/ws")
+    if host == "127.0.0.1":
+        print(f"For network access: restart with --host 0.0.0.0")
+    else:
+        print(f"Share this URL with beta testers: {display}")
     print("Press Ctrl+C to stop.")
     try:
         server.serve_forever()

--- a/static/index.html
+++ b/static/index.html
@@ -64,6 +64,16 @@
     .prop-key { color: #304060; flex-shrink: 0; }
     .prop-val { color: #8aaccc; text-align: right; word-break: break-word; }
 
+    /* ── Players panel ── */
+    #players-panel { flex-shrink: 0; max-height: 140px; overflow-y: auto; }
+    .player-row  { display: flex; align-items: center; gap: 7px; font-size: 10px; padding: 3px 0; }
+    .player-dot  { flex-shrink: 0; width: 8px; height: 8px; border-radius: 50%; }
+    .player-name { flex: 0 0 80px; color: #8aaccc; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .player-node { flex: 1; color: #4a6080; font-size: 9px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    #event-feed  { margin-top: 8px; border-top: 1px solid #111828; padding-top: 6px; }
+    .feed-item   { font-size: 9px; color: #3a5070; padding: 1px 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .feed-time   { color: #2a4050; margin-right: 4px; }
+
     /* ── Mode buttons ── */
     .mode-bar { display: flex; gap: 0; border-bottom: 1px solid #141828; }
     .mode-bar button { flex: 1; border: none; border-right: 1px solid #141828; border-radius: 0; padding: 8px 4px; font-size: 10px; color: #3a5070; background: #0b0d1a; }
@@ -112,9 +122,29 @@
 
     /* ── Status bar ── */
     .statusbar { flex: 0 0 auto; font-size: 10px; color: #2a4060; padding: 5px 16px; border-top: 1px solid #141828; background: #0b0d1a; letter-spacing: 1px; }
+
+    /* ── Join modal ── */
+    .modal-overlay { display: none; position: fixed; inset: 0; background: rgba(7,8,15,0.88); z-index: 100; align-items: center; justify-content: center; }
+    .modal-overlay.visible { display: flex; }
+    .modal-box { background: #0b0d1a; border: 1px solid #2a4060; padding: 32px 36px; min-width: 280px; display: flex; flex-direction: column; gap: 14px; }
+    .modal-title { font-size: 13px; letter-spacing: 3px; text-transform: uppercase; color: #3a8eff; }
+    .modal-desc  { font-size: 10px; color: #4a6080; letter-spacing: 1px; }
+    .modal-box input[type=text] { background: #10131f; border: 1px solid #222840; color: #b0bcd0; padding: 8px 10px; font-family: inherit; font-size: 13px; outline: none; }
+    .modal-box input[type=text]:focus { border-color: #3a8eff; }
+    .modal-box button { align-self: flex-start; }
   </style>
 </head>
 <body>
+
+<!-- Join modal -->
+<div id="join-modal" class="modal-overlay">
+  <div class="modal-box">
+    <div class="modal-title">Nested Worlds</div>
+    <div class="modal-desc">Choose a name for your explorer</div>
+    <input type="text" id="player-name-input" placeholder="Your name" maxlength="32" autocomplete="off">
+    <button onclick="joinModal()">Enter</button>
+  </div>
+</div>
 
 <header>
   <h1>Nested Worlds</h1>
@@ -140,6 +170,12 @@
       <div id="node-level" style="color:#3a8eff">—</div>
       <div id="node-name"  style="color:#3a8eff">Select a node</div>
       <div id="node-props"></div>
+    </div>
+
+    <div class="panel" id="players-panel">
+      <div class="panel-title">Explorers</div>
+      <div id="players-list"><div style="color:#2a4060;font-size:10px">Not connected</div></div>
+      <div id="event-feed"></div>
     </div>
 
     <div class="mode-bar">
@@ -200,6 +236,7 @@ let selected    = null;
 let worldParams = { seed: 42, depth: 6, min_b: 1, max_b: 3 };
 let puzzleState = { attempt: 0, maxAttempts: 3, solved: false };
 let observeES   = null;
+let nodeG       = null;  // D3 node <g> selection, kept alive for presence ring updates
 
 // ── SVG setup ──────────────────────────────────────────────────────────────
 const container = document.getElementById('graph');
@@ -236,6 +273,7 @@ async function loadWorld() {
     if (data.error) throw new Error(data.error);
     setStatus(`${data.node_count} nodes · seed ${seed} · depth ${depth}`);
     renderTree(data.world);
+    if (playerName) wsConnect(seed);
   } catch (e) {
     setStatus('Error: ' + e.message);
   } finally {
@@ -246,6 +284,10 @@ async function loadWorld() {
 // ── Render tree ────────────────────────────────────────────────────────────
 function renderTree(worldRoot) {
   root_g.selectAll('*').remove();
+  nodeG   = null;
+  players = {};
+  renderPlayers();
+
   const hier   = d3.hierarchy(worldRoot, d => d.children?.length ? d.children : null);
   const leaves = hier.leaves().length;
   const rowH   = Math.max(20, Math.min(40, (container.clientHeight - 60) / leaves));
@@ -256,7 +298,7 @@ function renderTree(worldRoot) {
     .attr('class', 'link')
     .attr('d', d3.linkHorizontal().x(d => d.y).y(d => d.x));
 
-  const nodeG = root_g.append('g').selectAll('g')
+  nodeG = root_g.append('g').selectAll('g')
     .data(hier.descendants()).join('g')
     .attr('class', 'node')
     .attr('transform', d => `translate(${d.y},${d.x})`)
@@ -316,6 +358,8 @@ function selectNode(data) {
   document.getElementById('puzzle-content').innerHTML = '';
   puzzleState = { attempt: 0, maxAttempts: 3, solved: false };
   if (observeES) { observeES.close(); observeES = null; }
+
+  wsSend({ type: 'move', node: data.name });
 }
 
 // ── Speak ──────────────────────────────────────────────────────────────────
@@ -479,8 +523,164 @@ async function submitAnswer() {
   }
 }
 
+// ── Multiplayer ────────────────────────────────────────────────────────────
+let playerName  = localStorage.getItem('nw_player_name') || null;
+let ws          = null;
+let mySessionId = null;
+let players     = {};
+let colorIdx    = 0;
+
+const PLAYER_COLORS = ['#ff6b6b','#ffd93d','#6bcb77','#4d96ff','#ff9ff3','#ff9f43','#54a0ff','#a29bfe'];
+const eventFeed = [];
+
+function showJoinModal() {
+  document.getElementById('join-modal').classList.add('visible');
+  setTimeout(() => document.getElementById('player-name-input').focus(), 50);
+}
+
+function hideJoinModal() {
+  document.getElementById('join-modal').classList.remove('visible');
+}
+
+function joinModal() {
+  const input = document.getElementById('player-name-input').value.trim();
+  if (!input) return;
+  playerName = input;
+  localStorage.setItem('nw_player_name', playerName);
+  hideJoinModal();
+  loadWorld();
+}
+
+document.getElementById('player-name-input').addEventListener('keydown', e => {
+  if (e.key === 'Enter') joinModal();
+});
+
+function wsConnect(seed) {
+  if (ws) { ws.close(); ws = null; }
+  players  = {};
+  colorIdx = 0;
+  renderPlayers();
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const url   = `${proto}//${window.location.host}/ws?seed=${seed}&name=${encodeURIComponent(playerName)}`;
+  try { ws = new WebSocket(url); } catch (_) { return; }
+  ws.onmessage = e => { try { handleWsMsg(JSON.parse(e.data)); } catch (_) {} };
+  ws.onclose   = () => { ws = null; };
+  ws.onerror   = () => {};
+}
+
+function wsSend(msg) {
+  if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(msg));
+}
+
+function assignColor() {
+  return PLAYER_COLORS[(colorIdx++) % PLAYER_COLORS.length];
+}
+
+function handleWsMsg(msg) {
+  switch (msg.type) {
+    case 'welcome':
+      mySessionId = msg.session_id;
+      players = {};
+      colorIdx = 0;
+      for (const p of (msg.players || [])) {
+        if (p.session_id !== mySessionId)
+          players[p.session_id] = { name: p.name, node: p.node, color: assignColor() };
+      }
+      renderPlayers();
+      updatePresenceRings();
+      break;
+    case 'player_join':
+      if (msg.session_id !== mySessionId) {
+        players[msg.session_id] = { name: msg.name, node: '', color: assignColor() };
+        pushFeed(`${msg.name} joined`);
+        renderPlayers();
+        updatePresenceRings();
+      }
+      break;
+    case 'player_leave':
+      if (players[msg.session_id]) {
+        pushFeed(`${players[msg.session_id].name} left`);
+        delete players[msg.session_id];
+        renderPlayers();
+        updatePresenceRings();
+      }
+      break;
+    case 'player_move':
+      if (players[msg.session_id]) {
+        players[msg.session_id].node = msg.node;
+        renderPlayers();
+        updatePresenceRings();
+      }
+      break;
+    case 'puzzle_solved':
+      pushFeed(`Puzzle solved: ${msg.puzzle} @ ${msg.node}`);
+      break;
+    case 'agent_done':
+      pushFeed(`Agent: ${msg.nodes_visited} nodes from ${msg.node}`);
+      break;
+  }
+}
+
+function renderPlayers() {
+  const el   = document.getElementById('players-list');
+  const list = Object.values(players);
+  if (!list.length) {
+    el.innerHTML = '<div style="color:#2a4060;font-size:10px">No other explorers online</div>';
+  } else {
+    el.innerHTML = list.map(p =>
+      `<div class="player-row">` +
+      `<span class="player-dot" style="background:${p.color}"></span>` +
+      `<span class="player-name">${escHtml(p.name)}</span>` +
+      `<span class="player-node">${escHtml(p.node || '—')}</span>` +
+      `</div>`
+    ).join('');
+  }
+}
+
+function pushFeed(text) {
+  const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  eventFeed.unshift({ text, time });
+  if (eventFeed.length > 5) eventFeed.pop();
+  document.getElementById('event-feed').innerHTML = eventFeed.map(e =>
+    `<div class="feed-item"><span class="feed-time">${e.time}</span>${escHtml(e.text)}</div>`
+  ).join('');
+}
+
+function updatePresenceRings() {
+  if (!nodeG) return;
+  nodeG.selectAll('.presence-ring').remove();
+  const nodeColors = {};
+  for (const p of Object.values(players)) {
+    if (!p.node) continue;
+    if (!nodeColors[p.node]) nodeColors[p.node] = [];
+    nodeColors[p.node].push(p.color);
+  }
+  for (const [nodeName, colors] of Object.entries(nodeColors)) {
+    const group = nodeG.filter(d => d.data.name === nodeName);
+    colors.forEach((color, i) => {
+      group.insert('circle', ':first-child')
+        .attr('class',          'presence-ring')
+        .attr('r',              d => (LEVEL_R[d.data.level] || 7) + 6 + i * 5)
+        .attr('fill',           'none')
+        .attr('stroke',         color)
+        .attr('stroke-width',   1.5)
+        .attr('stroke-dasharray', '4,3')
+        .attr('opacity',        0.8)
+        .attr('pointer-events', 'none');
+    });
+  }
+}
+
+function escHtml(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 // ── Boot ───────────────────────────────────────────────────────────────────
-loadWorld();
+if (playerName) {
+  loadWorld();
+} else {
+  showJoinModal();
+}
 </script>
 </body>
 </html>

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -28,7 +28,7 @@ class TestInitDb:
         conn = sqlite3.connect(persistence._DB_PATH)
         tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
         conn.close()
-        assert {"worlds", "agent_runs", "puzzle_results"}.issubset(tables)
+        assert {"worlds", "agent_runs", "puzzle_results", "world_mutations"}.issubset(tables)
 
     def test_db_permissions_owner_only(self):
         persistence.init_db()
@@ -77,6 +77,31 @@ class TestSaveAgentRun:
 
     def test_get_runs_unknown_seed(self):
         assert persistence.get_agent_runs(9999) == []
+
+
+class TestWorldMutations:
+    def test_record_and_get_mutation(self):
+        persistence.record_mutation(7, "Aethon", "PUZZLE_SOLVED", "Alice", {"puzzle": "The Lock"})
+        mutations = persistence.get_mutations(7)
+        assert len(mutations) == 1
+        m = mutations[0]
+        assert m["node"]   == "Aethon"
+        assert m["type"]   == "PUZZLE_SOLVED"
+        assert m["player"] == "Alice"
+        assert m["data"]   == {"puzzle": "The Lock"}
+
+    def test_get_mutations_unknown_seed(self):
+        assert persistence.get_mutations(9999) == []
+
+    def test_get_mutations_limit(self):
+        for i in range(10):
+            persistence.record_mutation(5, f"Node{i}", "PUZZLE_SOLVED", None, {})
+        assert len(persistence.get_mutations(5, limit=3)) == 3
+
+    def test_record_mutation_null_player(self):
+        persistence.record_mutation(3, "Vorrex", "PUZZLE_SOLVED", None, {"puzzle": "Riddle"})
+        mutations = persistence.get_mutations(3)
+        assert mutations[0]["player"] is None
 
 
 class TestSavePuzzleResult:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **WebSocket server** — RFC 6455 implemented from scratch in `server/__init__.py` (zero new dependencies). Each world seed gets its own room; players join, move, and leave in real time.
- **Live broadcasting** — `player_join`, `player_leave`, `player_move`, `puzzle_solved`, and `agent_done` events are pushed to every connected client in the same world.
- **Persistent world mutations** — new `world_mutations` SQLite table records meaningful events (puzzle solves) across sessions. `GET /history?seed=N` returns the last 50.
- **Player presence API** — `GET /players?seed=N` returns a live snapshot of who is in a given world.

## What's left (next session)

- `static/index.html` — join name modal, players panel in sidebar, WebSocket client, presence rings on graph nodes
- `main.py` — update `--host` default to `0.0.0.0` for easy beta sharing
- Persistence test update for the new `world_mutations` table

## Test plan

- [ ] `python main.py serve --host 0.0.0.0` starts cleanly and prints share URL
- [ ] Two browser tabs open `/?seed=42` and connect to `/ws?seed=42&name=Alice` / `&name=Bob`
- [ ] Moving between nodes in one tab broadcasts `player_move` to the other
- [ ] Solving a puzzle in one tab broadcasts `puzzle_solved` to the other and persists in `world_mutations`
- [ ] `GET /players?seed=42` reflects connected players
- [ ] `GET /history?seed=42` returns recorded mutations
- [ ] Tab close triggers `player_leave` broadcast

https://claude.ai/code/session_011tJiM8MBMqgeCDKsZkEMkt
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011tJiM8MBMqgeCDKsZkEMkt)_