### PR TITLE
Security hardening and refactoring: input validation, CSP headers, and utility consolidation

### DIFF
--- a/consciousness/__init__.py
+++ b/consciousness/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import threading
 from typing import Any
 
 from multiverse.node import SpatialNode
@@ -9,6 +10,7 @@ _MODEL = os.environ.get("NESTED_WORLDS_MODEL", "claude-opus-4-7")
 
 # Lazy-initialised so the module loads without requiring anthropic to be installed.
 _client: Any = None
+_client_lock = threading.Lock()
 
 _SYSTEM_PREAMBLE = (
     "You are a sentient entity within a nested multiverse simulation. "
@@ -21,8 +23,10 @@ _SYSTEM_PREAMBLE = (
 def _get_client() -> Any:
     global _client
     if _client is None:
-        from anthropic import Anthropic
-        _client = Anthropic()
+        with _client_lock:
+            if _client is None:
+                from anthropic import Anthropic
+                _client = Anthropic()
     return _client
 
 

--- a/interface/__init__.py
+++ b/interface/__init__.py
@@ -5,6 +5,7 @@ import time
 import causality
 from multiverse.generator import generate_node_hierarchy
 from multiverse.node import SpatialNode
+from multiverse.utils import _build_depth_map
 from puzzles.engine import PuzzleEngine
 from agents.agent import Agent
 
@@ -72,15 +73,6 @@ def _print_map(node: SpatialNode, prefix: str = "", is_last: bool = True,
     else:
         count = len(node.children)
         print(f"{child_prefix}└─ {_DIM}… ({count} child{'ren' if count != 1 else ''}){_RESET}")
-
-
-def _build_depth_map(node: SpatialNode, depth: int = 0, result: dict | None = None) -> dict[str, int]:
-    if result is None:
-        result = {}
-    result[node.id] = depth
-    for child in node.children:
-        _build_depth_map(child, depth + 1, result)
-    return result
 
 
 _AMBIENT_DAMPENING = 0.6

--- a/main.py
+++ b/main.py
@@ -150,7 +150,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_play.set_defaults(func=cmd_play)
 
     p_serve = sub.add_parser("serve", help="Start the REST API server")
-    p_serve.add_argument("--host", type=str, default="0.0.0.0", help="Bind host (default: 0.0.0.0)")
+    p_serve.add_argument("--host", type=str, default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
     p_serve.add_argument("--port", type=int, default=8080, help="Bind port (default: 8080)")
     p_serve.set_defaults(func=cmd_serve)
 

--- a/main.py
+++ b/main.py
@@ -4,21 +4,8 @@ import persistence
 from agents.agent import Agent
 from multiverse.generator import generate_node_hierarchy
 from multiverse.node import SpatialNode
+from multiverse.utils import _count_nodes, _find_node
 from puzzles.engine import PuzzleEngine
-
-
-def _count_nodes(node: SpatialNode) -> int:
-    return 1 + sum(_count_nodes(c) for c in node.children)
-
-
-def _find_node(root: SpatialNode, name: str) -> SpatialNode | None:
-    if root.name == name:
-        return root
-    for child in root.children:
-        found = _find_node(child, name)
-        if found:
-            return found
-    return None
 
 
 def cmd_world(args):

--- a/multiverse/utils.py
+++ b/multiverse/utils.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from multiverse.node import SpatialNode
+
+
+def _count_nodes(node: SpatialNode) -> int:
+    return 1 + sum(_count_nodes(c) for c in node.children)
+
+
+def _find_node(root: SpatialNode, name: str) -> SpatialNode | None:
+    if root.name == name:
+        return root
+    for child in root.children:
+        found = _find_node(child, name)
+        if found:
+            return found
+    return None
+
+
+def _build_depth_map(node: SpatialNode, depth: int = 0,
+                     result: dict | None = None) -> dict[str, int]:
+    if result is None:
+        result = {}
+    result[node.id] = depth
+    for child in node.children:
+        _build_depth_map(child, depth + 1, result)
+    return result

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -48,6 +48,8 @@ def _ws_recv(sock) -> bytes | None:
         length = struct.unpack(">H", _ws_recvall(sock, 2))[0]
     elif length == 127:
         length = struct.unpack(">Q", _ws_recvall(sock, 8))[0]
+    if length > 64 * 1024:
+        raise ValueError("WebSocket frame too large")
     mask_key = _ws_recvall(sock, 4) if masked else b""
     payload = bytearray(_ws_recvall(sock, length))
     if masked:
@@ -299,7 +301,13 @@ class _Handler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         path = urlparse(self.path).path.rstrip("/")
-        length = int(self.headers.get("Content-Length", 0))
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            length = 0
+        MAX_BODY = 64 * 1024  # 64 KB
+        if length > MAX_BODY:
+            return self._send_error("payload too large", 413)
         try:
             body = json.loads(self.rfile.read(length)) if length else {}
         except json.JSONDecodeError:
@@ -351,6 +359,7 @@ class _Handler(BaseHTTPRequestHandler):
         self.wfile.flush()
 
         sock = self.connection
+        sock.settimeout(60)  # 60-second idle timeout
         session_id = uuid.uuid4().hex[:8]
         player = _Player(name=name, seed=seed, current_node="", session_id=session_id, sock=sock)
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -17,6 +17,7 @@ import causality
 from agents.agent import Agent
 from multiverse.generator import generate_node_hierarchy
 from multiverse.node import SpatialNode
+from multiverse.utils import _build_depth_map, _count_nodes, _find_node
 from puzzles.engine import PuzzleEngine
 import persistence
 
@@ -145,30 +146,6 @@ def _node_to_dict(node: SpatialNode) -> dict:
         "properties": node.properties,
         "children": [_node_to_dict(c) for c in node.children],
     }
-
-
-def _count_nodes(node: SpatialNode) -> int:
-    return 1 + sum(_count_nodes(c) for c in node.children)
-
-
-def _find_node(root: SpatialNode, name: str) -> SpatialNode | None:
-    if root.name == name:
-        return root
-    for child in root.children:
-        found = _find_node(child, name)
-        if found:
-            return found
-    return None
-
-
-def _build_depth_map(node: SpatialNode, depth: int = 0,
-                     result: dict | None = None) -> dict[str, int]:
-    if result is None:
-        result = {}
-    result[node.id] = depth
-    for child in node.children:
-        _build_depth_map(child, depth + 1, result)
-    return result
 
 
 def _rebuild(params: dict) -> tuple[SpatialNode, int, int, int, int]:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -189,11 +189,17 @@ class _Handler(BaseHTTPRequestHandler):
 
     # ── response helpers ──
 
+    def _send_security_headers(self) -> None:
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header("Referrer-Policy", "no-referrer")
+
     def _send_json(self, data: object, status: int = 200) -> None:
         body = json.dumps(data, indent=2).encode()
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
+        self._send_security_headers()
         self.end_headers()
         self.wfile.write(body)
 
@@ -202,12 +208,25 @@ class _Handler(BaseHTTPRequestHandler):
 
     def _send_file(self, path: Path,
                    content_type: str = "text/html; charset=utf-8") -> None:
+        try:
+            path.resolve().relative_to(_STATIC_DIR.resolve())
+        except ValueError:
+            return self._send_error("forbidden", 403)
         if not path.exists():
             return self._send_error("not found", 404)
         body = path.read_bytes()
         self.send_response(200)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(body)))
+        self._send_security_headers()
+        if "text/html" in content_type:
+            self.send_header(
+                "Content-Security-Policy",
+                "default-src 'self'; "
+                "script-src 'self' https://d3js.org; "
+                "connect-src 'self' ws: wss:; "
+                "style-src 'self' 'unsafe-inline';",
+            )
         self.end_headers()
         self.wfile.write(body)
 
@@ -426,6 +445,7 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "text/event-stream")
         self.send_header("Cache-Control", "no-cache")
         self.send_header("Access-Control-Allow-Origin", "*")
+        self._send_security_headers()
         self.end_headers()
 
         depth_map = _build_depth_map(target)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import logging
 import struct
 import threading
 import uuid
@@ -21,6 +22,7 @@ import persistence
 
 _STATIC_DIR = Path(__file__).parent.parent / "static"
 _OBSERVE_LOCK = threading.Lock()
+_log = logging.getLogger("nested_worlds")
 _DAMPENING = 0.6
 _WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
@@ -314,20 +316,28 @@ class _Handler(BaseHTTPRequestHandler):
             return self._send_error("invalid JSON")
 
         if path == "/speak":
+            node_name       = str(body.get("node_name", "Unknown"))[:128]
+            node_level      = str(body.get("node_level", "Room"))[:64]
+            node_properties = body.get("node_properties", {})
+            if not isinstance(node_properties, dict):
+                node_properties = {}
+            message = str(body.get(
+                "message",
+                "Describe yourself to a traveler who has just arrived.",
+            ))[:1024]
             node = SpatialNode(
-                name=body.get("node_name", "Unknown"),
-                level=body.get("node_level", "Room"),
-                properties=body.get("node_properties", {}),
+                name=node_name,
+                level=node_level,
+                properties=node_properties,
             )
-            message = body.get("message",
-                                "Describe yourself to a traveler who has just arrived.")
             try:
                 import consciousness
                 self._send_json({"response": consciousness.speak(node, message)})
             except ImportError:
                 self._send_error("consciousness module requires: pip install anthropic")
             except Exception as exc:
-                self._send_error(str(exc))
+                _log.warning("speak error: %s", exc)
+                self._send_error("Service unavailable", 503)
 
         elif path == "/puzzle/attempt":
             self._do_puzzle_attempt(body)
@@ -549,6 +559,8 @@ class _ThreadedServer(ThreadingMixIn, HTTPServer):
 
 
 def run(host: str = "127.0.0.1", port: int = 8080) -> None:
+    logging.basicConfig(level=logging.WARNING,
+                        format="%(asctime)s %(levelname)s %(message)s")
     server = _ThreadedServer((host, port), _Handler)
     display = f"http://localhost:{port}" if host in ("0.0.0.0", "") else f"http://{host}:{port}"
     print(f"Nested Worlds Adventure  →  {display}")

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -480,9 +480,9 @@ class _Handler(BaseHTTPRequestHandler):
         except (ValueError, TypeError) as exc:
             return self._send_error(str(exc))
 
-        node_name = body.get("node_name", "")
-        answer    = body.get("answer", "").strip()
-        attempt   = int(body.get("attempt", 1))
+        node_name   = body.get("node_name", "")
+        answer      = body.get("answer", "").strip()
+        attempt_raw = body.get("attempt", 1)
 
         root   = generate_node_hierarchy(seed=seed, max_depth=depth,
                                          min_breadth=min_b, max_breadth=max_b)
@@ -495,7 +495,17 @@ class _Handler(BaseHTTPRequestHandler):
         if not puzzles:
             return self._send_error("no puzzle found")
 
-        p       = puzzles[0]
+        p = puzzles[0]
+        # Clamp attempt to [1, max_attempts+1] so a client cannot fabricate a
+        # false "failed" state (e.g. attempt=99999) to extract correct_answer.
+        # Values above max_attempts are still ≥ max_attempts so failed stays
+        # computable, but the correct_answer guard below only releases the
+        # answer when attempt is within the legitimate range (≤ max_attempts).
+        try:
+            attempt = max(1, min(int(attempt_raw), p.max_attempts + 1))
+        except (ValueError, TypeError):
+            attempt = 1
+
         correct = answer.lower() == p.answer.lower()
         failed  = not correct and attempt >= p.max_attempts
         hint    = (p.hints[attempt - 1]
@@ -516,7 +526,10 @@ class _Handler(BaseHTTPRequestHandler):
             "hint":           hint,
             "attempt":        attempt,
             "max_attempts":   p.max_attempts,
-            "correct_answer": p.answer if failed else None,
+            # Only reveal the answer when the server confirms failure at the
+            # legitimate last attempt (attempt ≤ max_attempts).  An out-of-
+            # bounds attempt (clamped to max_attempts+1) is excluded here.
+            "correct_answer": p.answer if (failed and attempt <= p.max_attempts) else None,
         })
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <title>Nested Worlds Adventure</title>
-  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <script src="https://d3js.org/d3.v7.min.js"
+          integrity="sha384-rRoXxn2yHlrZYB587Ki9RO1tONhLdM6XfORg7Rw4uwH4/Fh/5nP7IUX91bkaKUgs"
+          crossorigin="anonymous"></script>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -348,7 +350,7 @@ function selectNode(data) {
   document.getElementById('node-name').textContent  = data.name;
   document.getElementById('node-name').style.color  = color;
   document.getElementById('node-props').innerHTML = Object.entries(data.properties || {}).map(
-    ([k, v]) => `<div class="prop-row"><span class="prop-key">${k}</span><span class="prop-val">${v}</span></div>`
+    ([k, v]) => `<div class="prop-row"><span class="prop-key">${escHtml(String(k))}</span><span class="prop-val">${escHtml(String(v))}</span></div>`
   ).join('');
 
   // Reset panels
@@ -429,8 +431,8 @@ function appendObserveRow({ node, level, kind, strength }) {
   const row     = document.createElement('div');
   row.className = 'obs-row';
   row.innerHTML = `
-    <span class="obs-name"  style="color:${color}">${node}</span>
-    <span class="obs-event">${kindFmt}</span>
+    <span class="obs-name"  style="color:${color}">${escHtml(node)}</span>
+    <span class="obs-event">${escHtml(kindFmt)}</span>
     <span class="bar-track"><span class="bar-fill" style="width:${pct}%;background:${color}"></span></span>
     <span class="obs-strength">${strength.toFixed(2)}</span>`;
   const log = document.getElementById('observe-rows');
@@ -464,9 +466,9 @@ async function fetchPuzzle() {
 
 function renderPuzzle(data) {
   document.getElementById('puzzle-content').innerHTML = `
-    <div class="puzzle-kind">${data.kind.replace(/_/g, ' ')}</div>
-    <div class="puzzle-name">${data.name}</div>
-    <div class="puzzle-prompt">${data.prompt}</div>
+    <div class="puzzle-kind">${escHtml(data.kind.replace(/_/g, ' '))}</div>
+    <div class="puzzle-name">${escHtml(data.name)}</div>
+    <div class="puzzle-prompt">${escHtml(data.prompt)}</div>
     <div class="attempt-info" id="attempt-info">
       ${data.max_attempts} attempt${data.max_attempts !== 1 ? 's' : ''} allowed
     </div>

--- a/tests/test_consciousness.py
+++ b/tests/test_consciousness.py
@@ -1,0 +1,64 @@
+"""Thread-safety test for consciousness._get_client (T-2)."""
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from unittest.mock import MagicMock
+
+
+def test_get_client_thread_safety():
+    """Anthropic() must be called exactly once even with concurrent initialisation."""
+    mock_instance = MagicMock()
+    call_count = [0]
+    count_lock = threading.Lock()
+
+    def counting_anthropic():
+        with count_lock:
+            call_count[0] += 1
+        return mock_instance
+
+    # Inject a fake `anthropic` module so that `from anthropic import Anthropic`
+    # inside _get_client resolves to our counting stub — works whether or not
+    # the real package is installed.
+    fake_anthropic = types.ModuleType("anthropic")
+    fake_anthropic.Anthropic = counting_anthropic  # type: ignore[attr-defined]
+
+    import consciousness
+
+    original_module = sys.modules.get("anthropic")
+    sys.modules["anthropic"] = fake_anthropic
+    consciousness._client = None
+
+    try:
+        n_threads = 10
+        barrier = threading.Barrier(n_threads)
+        results: list = []
+        errors: list = []
+
+        def worker():
+            try:
+                barrier.wait()
+                client = consciousness._get_client()
+                results.append(client)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        if original_module is None:
+            sys.modules.pop("anthropic", None)
+        else:
+            sys.modules["anthropic"] = original_module
+        consciousness._client = None
+
+    assert not errors, f"Unexpected errors: {errors}"
+    assert call_count[0] == 1, (
+        f"Anthropic() called {call_count[0]} times; expected exactly 1"
+    )
+    assert len(results) == n_threads
+    assert all(r is mock_instance for r in results)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,102 @@
+"""Integration tests for the HTTP server layer (T-1)."""
+from __future__ import annotations
+
+import http.client
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+from server import _Handler, _ThreadedServer
+
+
+@pytest.fixture(scope="module")
+def srv():
+    server = _ThreadedServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{port}", port
+    server.shutdown()
+
+
+def _get(url: str):
+    with urllib.request.urlopen(url) as resp:
+        return json.loads(resp.read()), resp.status, resp.headers
+
+
+def _post(url: str, data: dict):
+    body = json.dumps(data).encode()
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read()), resp.status
+
+
+class TestServerHTTP:
+    def test_health(self, srv):
+        base, _ = srv
+        data, status, _ = _get(f"{base}/health")
+        assert status == 200
+        assert data == {"status": "ok"}
+
+    def test_world_valid(self, srv):
+        base, _ = srv
+        data, status, _ = _get(
+            f"{base}/world?seed=1&depth=4&min_breadth=1&max_breadth=2"
+        )
+        assert status == 200
+        assert data["node_count"] > 0
+
+    def test_world_invalid_seed(self, srv):
+        base, _ = srv
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            _get(f"{base}/world?seed=abc")
+        assert exc_info.value.code == 400
+
+    def test_puzzle_attempt_no_leak(self, srv):
+        """C-1 regression: attempt=99999 must not reveal correct_answer."""
+        base, _ = srv
+        data, _ = _post(
+            f"{base}/puzzle/attempt",
+            {
+                "seed": 42,
+                "depth": 6,
+                "min_breadth": 1,
+                "max_breadth": 3,
+                "node_name": "",
+                "answer": "definitely_wrong_answer_xyzzy",
+                "attempt": 99999,
+            },
+        )
+        assert data.get("correct_answer") is None
+
+    def test_body_too_large(self, srv):
+        """H-1: Content-Length > 64 KB must return 413."""
+        base, port = srv
+        conn = http.client.HTTPConnection("127.0.0.1", port)
+        conn.putrequest("POST", "/speak")
+        conn.putheader("Content-Type", "application/json")
+        conn.putheader("Content-Length", str(65 * 1024 + 1))
+        conn.endheaders()
+        conn.send(b"{}")
+        resp = conn.getresponse()
+        status = resp.status
+        resp.read()
+        conn.close()
+        assert status == 413
+
+    def test_players(self, srv):
+        base, _ = srv
+        data, status, _ = _get(f"{base}/players?seed=1")
+        assert status == 200
+        assert "players" in data
+
+    def test_static_html(self, srv):
+        base, _ = srv
+        with urllib.request.urlopen(f"{base}/") as resp:
+            assert resp.status == 200
+            assert "text/html" in resp.headers.get("Content-Type", "")

--- a/tests/test_server_security.py
+++ b/tests/test_server_security.py
@@ -1,0 +1,48 @@
+"""Regression tests for server-side security fixes."""
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+
+import pytest
+
+from server import _Handler, _ThreadedServer
+
+
+@pytest.fixture(scope="module")
+def srv_url():
+    srv = _ThreadedServer(("127.0.0.1", 0), _Handler)
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{port}"
+    srv.shutdown()
+
+
+def _post_json(url: str, data: dict) -> dict:
+    body = json.dumps(data).encode()
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def test_attempt_leak_prevented(srv_url):
+    """C-1: attempt=99999 must NOT reveal correct_answer."""
+    data = _post_json(
+        f"{srv_url}/puzzle/attempt",
+        {
+            "seed": 42,
+            "depth": 6,
+            "min_breadth": 1,
+            "max_breadth": 3,
+            "node_name": "",
+            "answer": "definitely_wrong_answer_xyzzy",
+            "attempt": 99999,
+        },
+    )
+    assert data.get("correct_answer") is None, (
+        "correct_answer must be None when attempt is out-of-bounds"
+    )


### PR DESCRIPTION
## Summary
This PR implements comprehensive security hardening across the server layer, adds input validation and size limits, consolidates utility functions into a shared module, and includes new integration tests.

## Key Changes

**Security & Input Validation:**
- Added WebSocket frame size limit (64 KB) with validation in `_ws_recv()`
- Implemented POST body size limit (64 KB) with 413 response for oversized payloads
- Added Content-Security-Policy headers for HTML responses with strict directives
- Added security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`) to all JSON and file responses
- Implemented path traversal protection in `_send_file()` using `relative_to()` validation

**Puzzle Attempt Security (C-1 regression fix):**
- Clamped `attempt` parameter to valid range `[1, max_attempts+1]` to prevent clients from fabricating false "failed" states
- Modified `correct_answer` revelation logic to only expose answers when `attempt <= max_attempts`, preventing extraction via out-of-bounds values

**Input Sanitization:**
- Added string length limits and type coercion for `/speak` endpoint parameters (node_name: 128 chars, node_level: 64 chars, message: 1024 chars)
- Added HTML escaping (`escHtml()`) in frontend for node names, properties, and puzzle content to prevent XSS
- Added SRI (Subresource Integrity) hash to d3.js CDN script tag

**Code Refactoring:**
- Extracted `_count_nodes()`, `_find_node()`, and `_build_depth_map()` utility functions from `server/__init__.py` and `main.py` into new `multiverse/utils.py` module
- Updated imports across `server/__init__.py`, `main.py`, and `interface/__init__.py` to use consolidated utilities

**Thread Safety & Logging:**
- Added thread-safe lazy initialization of Anthropic client in `consciousness._get_client()` using `threading.Lock()`
- Added logging infrastructure with `logging.basicConfig()` in server startup
- Improved error handling in `/speak` endpoint with proper logging instead of exposing raw exceptions

**Server Configuration:**
- Changed default bind host from `0.0.0.0` to `127.0.0.1` for improved security posture
- Added 60-second idle timeout to WebSocket connections

**Testing:**
- Added comprehensive integration test suite (`tests/test_server.py`) covering health checks, world generation, puzzle attempts, body size limits, and static file serving
- Added thread-safety regression test for consciousness module (`tests/test_consciousness.py`)
- Added security-focused regression tests (`tests/test_server_security.py`) for attempt parameter leak prevention

## Notable Implementation Details

- The attempt clamping strategy allows legitimate attempts to work normally while preventing out-of-bounds values from triggering the answer reveal logic
- Path traversal protection uses `resolve().relative_to()` to ensure all file access stays within the static directory
- Frontend HTML escaping uses a utility function to safely render user-controlled data in DOM
- Logging is configured at server startup with WARNING level to avoid noise while capturing important events

https://claude.ai/code/session_01VN5aujWaRpJQ7XyXzKwZHo