### PR TITLE
refactor: causality bus + cleanup pass (medium/low priority)

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 from multiverse.node import SpatialNode
-from agents.behaviors import State, transition, should_preserve
+from agents.behaviors import DEFAULT_DANGER_THRESHOLD, State, transition, should_preserve
 import causality
-from causality import EventKind
+from causality import CausalityBus, EventKind
 
 
 @dataclass
@@ -17,10 +17,15 @@ class AgentLog:
 @dataclass
 class Agent:
     name: str
-    danger_threshold: int = 6
+    danger_threshold: int = DEFAULT_DANGER_THRESHOLD
     state: State = State.IDLE
     log: List[AgentLog] = field(default_factory=list)
     visited: List[str] = field(default_factory=list)
+    bus: Optional[CausalityBus] = None
+
+    @property
+    def _bus(self) -> CausalityBus:
+        return self.bus if self.bus is not None else causality._default
 
     def _record(self, node: SpatialNode, action: str) -> None:
         self.log.append(AgentLog(
@@ -34,17 +39,17 @@ class Agent:
         if self.state == State.EXPLORE:
             if should_preserve(node, self.danger_threshold):
                 self._record(node, f"withdrew (danger_level={node.properties.get('danger_level')})")
-                causality.emit(node, EventKind.DANGER_ALERT, {"agent": self.name})
+                self._bus.emit(node, EventKind.DANGER_ALERT, {"agent": self.name})
                 return False
             self._record(node, "explored")
-            causality.emit(node, EventKind.AGENT_VISIT, {"agent": self.name})
+            self._bus.emit(node, EventKind.AGENT_VISIT, {"agent": self.name})
 
         elif self.state == State.INTERACT:
             has_puzzle = node.properties.get("has_puzzle")
             detail = "interacted with puzzle" if has_puzzle else "interacted"
             self._record(node, detail)
             kind = EventKind.PUZZLE_SOLVED if has_puzzle else EventKind.AGENT_VISIT
-            causality.propagate(node, kind, {"agent": self.name})
+            self._bus.propagate(node, kind, {"agent": self.name})
 
         elif self.state == State.EXIT:
             if should_preserve(node, self.danger_threshold):
@@ -60,24 +65,23 @@ class Agent:
         self.state = State.IDLE
         self.log = []
         self.visited = []
-        self._traverse(node, max_nodes, depth=0)
+        self._traverse(node, max_nodes)
 
-    def _traverse(self, node: SpatialNode, max_nodes: int, depth: int) -> None:
-        # Depth guard prevents runaway recursion on pathological trees
-        if len(self.visited) >= max_nodes or depth > 500:
+    def _traverse(self, node: SpatialNode, max_nodes: int) -> None:
+        if len(self.visited) >= max_nodes:
             return
         if node.id in self.visited:
             return
 
         self.visited.append(node.id)
-        self.state = transition(self.state, node)
+        self.state = transition(self.state, node, self.danger_threshold)
         should_descend = self._act(node)
 
         if should_descend and self.state != State.EXIT:
             for child in node.children:
                 if len(self.visited) >= max_nodes:
                     break
-                self._traverse(child, max_nodes, depth + 1)
+                self._traverse(child, max_nodes)
 
     def report(self) -> str:
         lines = [f"Agent '{self.name}' traversal report ({len(self.log)} events):"]

--- a/agents/behaviors.py
+++ b/agents/behaviors.py
@@ -3,6 +3,9 @@
 from enum import Enum, auto
 
 
+DEFAULT_DANGER_THRESHOLD = 6
+
+
 class State(Enum):
     IDLE = auto()
     EXPLORE = auto()
@@ -10,7 +13,7 @@ class State(Enum):
     EXIT = auto()
 
 
-def should_preserve(node, danger_threshold: int = 6) -> bool:
+def should_preserve(node, danger_threshold: int = DEFAULT_DANGER_THRESHOLD) -> bool:
     return node.properties.get("danger_level", 0) > danger_threshold
 
 
@@ -22,12 +25,12 @@ def should_exit(node) -> bool:
     return node.properties.get("locked", False) and not node.children
 
 
-def transition(state: State, node) -> State:
+def transition(state: State, node, danger_threshold: int = DEFAULT_DANGER_THRESHOLD) -> State:
     if state == State.IDLE:
         return State.EXPLORE
 
     if state == State.EXPLORE:
-        if should_preserve(node):
+        if should_preserve(node, danger_threshold):
             return State.EXIT
         if should_interact(node):
             return State.INTERACT

--- a/causality/__init__.py
+++ b/causality/__init__.py
@@ -38,73 +38,108 @@ class CausalEvent:
 # Signature: (node: SpatialNode, event: CausalEvent) -> None
 Handler = Callable[["SpatialNode", CausalEvent], None]
 
-_MIN_STRENGTH: float = 0.05
-_handlers: list[Handler] = []
-_event_log: list[tuple[str, CausalEvent]] = []
+MIN_STRENGTH: float = 0.05
+DAMPENING: float = 0.6   # default per-depth attenuation factor
+
+
+class CausalityBus:
+    """Encapsulates handlers and event log for causal events.
+
+    A bus instance is independent of any other.  The module exposes a default
+    singleton (``_default``) plus convenience functions that delegate to it,
+    so existing call sites work unchanged; the server and interface create
+    their own buses for isolated observation runs.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: list[Handler] = []
+        self._event_log: list[tuple[str, CausalEvent]] = []
+
+    def register_handler(self, fn: Handler) -> None:
+        self._handlers.append(fn)
+
+    def clear_handlers(self) -> None:
+        self._handlers.clear()
+
+    def get_log(self) -> list[tuple[str, CausalEvent]]:
+        return list(self._event_log)
+
+    def clear_log(self) -> None:
+        self._event_log.clear()
+
+    def emit(self, node: SpatialNode, kind: EventKind,
+             payload: dict[str, Any] | None = None) -> CausalEvent:
+        """Create a full-strength event at *node* without propagating."""
+        event = CausalEvent(
+            kind=kind,
+            origin_id=node.id,
+            origin_level=node.level,
+            strength=1.0,
+            payload=payload or {},
+        )
+        self._fire(node, event)
+        return event
+
+    def propagate(self, origin: SpatialNode, kind: EventKind,
+                  payload: dict[str, Any] | None = None,
+                  dampening: float = 0.5) -> CausalEvent:
+        """Emit at *origin* and cascade downward; halts when strength < MIN_STRENGTH."""
+        event = CausalEvent(
+            kind=kind,
+            origin_id=origin.id,
+            origin_level=origin.level,
+            strength=1.0,
+            payload=payload or {},
+        )
+        self._cascade(origin, event, dampening)
+        return event
+
+    def _fire(self, node: SpatialNode, event: CausalEvent) -> None:
+        self._event_log.append((node.name, event))
+        for handler in self._handlers:
+            handler(node, event)
+
+    def _cascade(self, node: SpatialNode, event: CausalEvent, dampening: float) -> None:
+        if event.strength < MIN_STRENGTH:
+            return
+        self._fire(node, event)
+        child_event = event.dampen(dampening)
+        for child in node.children:
+            self._cascade(child, child_event, dampening)
+
+
+# Default module-level bus.  Most code uses the convenience wrappers below;
+# code that needs isolation (per-request observers, tests) should construct
+# its own CausalityBus and pass it explicitly.
+_default = CausalityBus()
 
 
 def register_handler(fn: Handler) -> None:
-    """Register a callback invoked for every causal event that reaches a node."""
-    _handlers.append(fn)
+    _default.register_handler(fn)
 
 
 def clear_handlers() -> None:
-    _handlers.clear()
+    _default.clear_handlers()
 
 
 def get_log() -> list[tuple[str, CausalEvent]]:
-    """Return a snapshot of all (node_name, event) pairs recorded so far."""
-    return list(_event_log)
+    return _default.get_log()
 
 
 def clear_log() -> None:
-    _event_log.clear()
+    _default.clear_log()
 
 
-def emit(node: SpatialNode, kind: EventKind, payload: dict[str, Any] | None = None) -> CausalEvent:
-    """Create a full-strength event at *node* without propagating to children."""
-    event = CausalEvent(
-        kind=kind,
-        origin_id=node.id,
-        origin_level=node.level,
-        strength=1.0,
-        payload=payload or {},
-    )
-    _fire(node, event)
-    return event
+def emit(node: SpatialNode, kind: EventKind,
+         payload: dict[str, Any] | None = None) -> CausalEvent:
+    return _default.emit(node, kind, payload)
 
 
-def propagate(
-    origin: SpatialNode,
-    kind: EventKind,
-    payload: dict[str, Any] | None = None,
-    dampening: float = 0.5,
-) -> CausalEvent:
-    """Emit an event at *origin* at full strength, then cascade it downward
-    through all descendants.  Strength is multiplied by *dampening* at each
-    additional depth level; propagation halts when strength < _MIN_STRENGTH.
-    """
-    event = CausalEvent(
-        kind=kind,
-        origin_id=origin.id,
-        origin_level=origin.level,
-        strength=1.0,
-        payload=payload or {},
-    )
-    _cascade(origin, event, dampening)
-    return event
+def propagate(origin: SpatialNode, kind: EventKind,
+              payload: dict[str, Any] | None = None,
+              dampening: float = 0.5) -> CausalEvent:
+    return _default.propagate(origin, kind, payload, dampening)
 
 
-def _fire(node: SpatialNode, event: CausalEvent) -> None:
-    _event_log.append((node.name, event))
-    for handler in _handlers:
-        handler(node, event)
-
-
-def _cascade(node: SpatialNode, event: CausalEvent, dampening: float) -> None:
-    if event.strength < _MIN_STRENGTH:
-        return
-    _fire(node, event)
-    child_event = event.dampen(dampening)
-    for child in node.children:
-        _cascade(child, child_event, dampening)
+# Backward-compat alias for the threshold constant.
+_MIN_STRENGTH = MIN_STRENGTH

--- a/interface/__init__.py
+++ b/interface/__init__.py
@@ -5,7 +5,7 @@ import time
 import causality
 from multiverse.generator import generate_node_hierarchy
 from multiverse.node import SpatialNode
-from multiverse.utils import _build_depth_map
+from multiverse.utils import build_depth_map
 from puzzles.engine import PuzzleEngine
 from agents.agent import Agent
 
@@ -75,7 +75,7 @@ def _print_map(node: SpatialNode, prefix: str = "", is_last: bool = True,
         print(f"{child_prefix}└─ {_DIM}… ({count} child{'ren' if count != 1 else ''}){_RESET}")
 
 
-_AMBIENT_DAMPENING = 0.6
+_AMBIENT_DAMPENING = causality.DAMPENING
 
 
 def _ambient_mode(node: SpatialNode) -> None:
@@ -83,7 +83,7 @@ def _ambient_mode(node: SpatialNode) -> None:
     print(f"  {'Node':<30}  {'Event':<22}  {'Strength'}")
     print(f"  {_DIM}{'─'*30}  {'─'*22}  {'─'*20}{_RESET}")
 
-    depth_map = _build_depth_map(node)
+    depth_map = build_depth_map(node)
 
     def _handler(n: SpatialNode, event: causality.CausalEvent) -> None:
         style = _LEVEL_STYLES.get(n.level, "")
@@ -95,15 +95,12 @@ def _ambient_mode(node: SpatialNode) -> None:
         print(f"  {style}{n.name:<30}{_RESET}  {kind:<22}  {bar}  {strength:.2f}")
         time.sleep(0.04)
 
-    causality.register_handler(_handler)
-    try:
-        agent = Agent(name="Observer", danger_threshold=7)
-        agent.traverse(node, max_nodes=40)
-        print(f"\n{_DIM}Observer visited {len(agent.visited)} node(s). Press Enter to continue.{_RESET}")
-        input()
-    finally:
-        causality.clear_handlers()
-        causality.clear_log()
+    bus = causality.CausalityBus()
+    bus.register_handler(_handler)
+    agent = Agent(name="Observer", danger_threshold=7, bus=bus)
+    agent.traverse(node, max_nodes=40)
+    print(f"\n{_DIM}Observer visited {len(agent.visited)} node(s). Press Enter to continue.{_RESET}")
+    input()
 
 
 def _play_puzzle(node: SpatialNode, seed: int) -> None:

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import persistence
 from agents.agent import Agent
 from multiverse.generator import generate_node_hierarchy
 from multiverse.node import SpatialNode
-from multiverse.utils import _count_nodes, _find_node
+from multiverse.utils import count_nodes, find_node
 from puzzles.engine import PuzzleEngine
 
 
@@ -16,7 +16,7 @@ def cmd_world(args):
         max_breadth=args.max_breadth,
     )
     print(root)
-    node_count = _count_nodes(root)
+    node_count = count_nodes(root)
     persistence.save_world(args.seed, node_count, args.depth, args.min_breadth, args.max_breadth)
     print(f"[Saved: seed={args.seed}, {node_count} nodes]")
 
@@ -89,7 +89,7 @@ def cmd_speak(args):
         return
 
     root = generate_node_hierarchy(seed=args.seed)
-    target = _find_node(root, args.node) if args.node else root
+    target = find_node(root, args.node) if args.node else root
     if target is None:
         print(f"Node '{args.node}' not found in seed={args.seed}. Run 'world' to see available nodes.")
         return

--- a/multiverse/generator.py
+++ b/multiverse/generator.py
@@ -1,6 +1,8 @@
 # multiverse/generator.py
 
 import random
+from typing import Callable
+
 from multiverse.node import SpatialNode
 
 LEVELS = [
@@ -33,72 +35,121 @@ def _pick(pool: list, rng: random.Random) -> str:
     return rng.choice(pool)
 
 
-def generate_properties(level: str, rng: random.Random) -> dict:
-    templates = {
-        "Multiverse": {
-            "theme": _pick(["entropy", "expansion", "paradox", "recursion", "stillness"], rng),
-            "age_billion_years": round(rng.uniform(1.0, 100.0), 1),
-            "stability": _pick(["stable", "fraying", "collapsing"], rng),
-        },
-        "Universe": {
-            "laws_of_physics": _pick(["Newtonian", "Quantum", "Fractal", "Inverted", "Probabilistic"], rng),
-            "dark_matter_ratio": round(rng.uniform(0.1, 0.9), 2),
-            "dominant_faction": _pick(_FACTIONS, rng),
-        },
-        "Galaxy": {
-            "star_density": rng.randint(50, 500),
-            "shape": _pick(["spiral", "elliptical", "irregular", "ring"], rng),
-            "black_hole_mass_solar": rng.randint(100_000, 10_000_000),
-        },
-        "Planetary System": {
-            "star_type": _pick(["yellow dwarf", "red dwarf", "white dwarf", "binary", "neutron star"], rng),
-            "planet_count": rng.randint(1, 12),
-            "habitable_zone": rng.choice([True, False]),
-            "asteroid_belt": rng.choice([True, False]),
-        },
-        "Planet": {
-            "gravity": round(rng.uniform(0.1, 3.5), 2),
-            "biome": _pick(_BIOMES, rng),
-            "inhabited": rng.choice([True, False]),
-            "population": rng.randint(0, 10_000_000_000) if rng.random() > 0.4 else 0,
-            "moons": rng.randint(0, 8),
-        },
-        "Region": {
-            "danger_level": rng.randint(1, 10),
-            "terrain": _pick(["ruins", "wilderness", "urban", "underground", "floating"], rng),
-            "faction_control": _pick(_FACTIONS + ["contested", "none"], rng),
-            "has_settlement": rng.choice([True, False]),
-        },
-        "Room": {
-            "has_puzzle": rng.choice([True, False]),
-            "locked": rng.choice([True, False]),
-            "lighting": _pick(["bright", "dim", "dark", "flickering"], rng),
-            "exits": rng.randint(1, 4),
-            "contains_npc": rng.choice([True, False]),
-        },
-        "Object": {
-            "interactive": rng.choice([True, False]),
-            "material": _pick(["stone", "metal", "crystal", "wood", "energy", "bone"], rng),
-            "condition": _pick(["pristine", "worn", "damaged", "corrupted"], rng),
-            "weight_kg": round(rng.uniform(0.01, 500.0), 2),
-        },
-        "Molecule": {
-            "compound_type": _pick(["organic", "inorganic", "synthetic", "exotic"], rng),
-            "bond_count": rng.randint(1, 12),
-            "reactive": rng.choice([True, False]),
-        },
-        "Atom": {
-            "element": _pick(["H", "C", "O", "N", "Fe", "Au", "Si", "Xe", "Pb", "U"], rng),
-            "ionized": rng.choice([True, False]),
-            "atomic_number": rng.randint(1, 118),
-        },
-        "SubatomicParticle": {
-            "particle_type": _pick(["proton", "neutron", "electron", "quark", "neutrino", "photon"], rng),
-            "spin": _pick(["up", "down", "superposed"], rng),
-            "charge": _pick([-1, 0, 1], rng),
-        },
+# ── Per-level property generators ──────────────────────────────────────────
+
+def _props_multiverse(rng: random.Random) -> dict:
+    return {
+        "theme": _pick(["entropy", "expansion", "paradox", "recursion", "stillness"], rng),
+        "age_billion_years": round(rng.uniform(1.0, 100.0), 1),
+        "stability": _pick(["stable", "fraying", "collapsing"], rng),
     }
-    return templates.get(level, {})
+
+
+def _props_universe(rng: random.Random) -> dict:
+    return {
+        "laws_of_physics": _pick(["Newtonian", "Quantum", "Fractal", "Inverted", "Probabilistic"], rng),
+        "dark_matter_ratio": round(rng.uniform(0.1, 0.9), 2),
+        "dominant_faction": _pick(_FACTIONS, rng),
+    }
+
+
+def _props_galaxy(rng: random.Random) -> dict:
+    return {
+        "star_density": rng.randint(50, 500),
+        "shape": _pick(["spiral", "elliptical", "irregular", "ring"], rng),
+        "black_hole_mass_solar": rng.randint(100_000, 10_000_000),
+    }
+
+
+def _props_planetary_system(rng: random.Random) -> dict:
+    return {
+        "star_type": _pick(["yellow dwarf", "red dwarf", "white dwarf", "binary", "neutron star"], rng),
+        "planet_count": rng.randint(1, 12),
+        "habitable_zone": rng.choice([True, False]),
+        "asteroid_belt": rng.choice([True, False]),
+    }
+
+
+def _props_planet(rng: random.Random) -> dict:
+    return {
+        "gravity": round(rng.uniform(0.1, 3.5), 2),
+        "biome": _pick(_BIOMES, rng),
+        "inhabited": rng.choice([True, False]),
+        "population": rng.randint(0, 10_000_000_000) if rng.random() > 0.4 else 0,
+        "moons": rng.randint(0, 8),
+    }
+
+
+def _props_region(rng: random.Random) -> dict:
+    return {
+        "danger_level": rng.randint(1, 10),
+        "terrain": _pick(["ruins", "wilderness", "urban", "underground", "floating"], rng),
+        "faction_control": _pick(_FACTIONS + ["contested", "none"], rng),
+        "has_settlement": rng.choice([True, False]),
+    }
+
+
+def _props_room(rng: random.Random) -> dict:
+    return {
+        "has_puzzle": rng.choice([True, False]),
+        "locked": rng.choice([True, False]),
+        "lighting": _pick(["bright", "dim", "dark", "flickering"], rng),
+        "exits": rng.randint(1, 4),
+        "contains_npc": rng.choice([True, False]),
+    }
+
+
+def _props_object(rng: random.Random) -> dict:
+    return {
+        "interactive": rng.choice([True, False]),
+        "material": _pick(["stone", "metal", "crystal", "wood", "energy", "bone"], rng),
+        "condition": _pick(["pristine", "worn", "damaged", "corrupted"], rng),
+        "weight_kg": round(rng.uniform(0.01, 500.0), 2),
+    }
+
+
+def _props_molecule(rng: random.Random) -> dict:
+    return {
+        "compound_type": _pick(["organic", "inorganic", "synthetic", "exotic"], rng),
+        "bond_count": rng.randint(1, 12),
+        "reactive": rng.choice([True, False]),
+    }
+
+
+def _props_atom(rng: random.Random) -> dict:
+    return {
+        "element": _pick(["H", "C", "O", "N", "Fe", "Au", "Si", "Xe", "Pb", "U"], rng),
+        "ionized": rng.choice([True, False]),
+        "atomic_number": rng.randint(1, 118),
+    }
+
+
+def _props_subatomic(rng: random.Random) -> dict:
+    return {
+        "particle_type": _pick(["proton", "neutron", "electron", "quark", "neutrino", "photon"], rng),
+        "spin": _pick(["up", "down", "superposed"], rng),
+        "charge": _pick([-1, 0, 1], rng),
+    }
+
+
+_LEVEL_GENERATORS: dict[str, Callable[[random.Random], dict]] = {
+    "Multiverse":        _props_multiverse,
+    "Universe":          _props_universe,
+    "Galaxy":            _props_galaxy,
+    "Planetary System":  _props_planetary_system,
+    "Planet":            _props_planet,
+    "Region":            _props_region,
+    "Room":              _props_room,
+    "Object":            _props_object,
+    "Molecule":          _props_molecule,
+    "Atom":              _props_atom,
+    "SubatomicParticle": _props_subatomic,
+}
+
+
+def generate_properties(level: str, rng: random.Random) -> dict:
+    gen = _LEVEL_GENERATORS.get(level)
+    return gen(rng) if gen else {}
 
 
 _NAME_POOLS = {
@@ -127,20 +178,21 @@ def generate_node_hierarchy(seed: int = 42, max_depth: int = 11, min_breadth: in
     if not 1 <= max_depth <= len(LEVELS):
         raise ValueError(f"max_depth must be between 1 and {len(LEVELS)}, got {max_depth}")
     rng = random.Random(seed)
-    counter = [0]
+    next_index = 0
 
-    def _generate(level_index: int) -> SpatialNode:
+    def generate(level_index: int) -> SpatialNode:
+        nonlocal next_index
+        next_index += 1
         level = LEVELS[level_index]
-        counter[0] += 1
-        name = _generate_name(level, counter[0], rng)
+        name = _generate_name(level, next_index, rng)
         properties = generate_properties(level, rng)
         node = SpatialNode(name=name, level=level, properties=properties)
 
         if level_index + 1 < max_depth:
             breadth = rng.randint(min_breadth, max_breadth)
             for _ in range(breadth):
-                node.add_child(_generate(level_index + 1))
+                node.add_child(generate(level_index + 1))
 
         return node
 
-    return _generate(0)
+    return generate(0)

--- a/multiverse/utils.py
+++ b/multiverse/utils.py
@@ -3,25 +3,25 @@ from __future__ import annotations
 from multiverse.node import SpatialNode
 
 
-def _count_nodes(node: SpatialNode) -> int:
-    return 1 + sum(_count_nodes(c) for c in node.children)
+def count_nodes(node: SpatialNode) -> int:
+    return 1 + sum(count_nodes(c) for c in node.children)
 
 
-def _find_node(root: SpatialNode, name: str) -> SpatialNode | None:
+def find_node(root: SpatialNode, name: str) -> SpatialNode | None:
     if root.name == name:
         return root
     for child in root.children:
-        found = _find_node(child, name)
+        found = find_node(child, name)
         if found:
             return found
     return None
 
 
-def _build_depth_map(node: SpatialNode, depth: int = 0,
-                     result: dict | None = None) -> dict[str, int]:
+def build_depth_map(node: SpatialNode, depth: int = 0,
+                    result: dict | None = None) -> dict[str, int]:
     if result is None:
         result = {}
     result[node.id] = depth
     for child in node.children:
-        _build_depth_map(child, depth + 1, result)
+        build_depth_map(child, depth + 1, result)
     return result

--- a/puzzles/engine.py
+++ b/puzzles/engine.py
@@ -78,28 +78,22 @@ class PuzzleEngine:
         self._rng = random.Random(seed)
 
     def attach_puzzles(self, root: SpatialNode) -> int:
-        count_ref = [0]
-        self._attach(root, count_ref)
-        return count_ref[0]
-
-    def _attach(self, node: SpatialNode, count_ref: list):
-        if "puzzle" not in node.properties:
-            node.properties["puzzle"] = _make_puzzle_for_node(node, self._rng)
-            count_ref[0] += 1
-        for child in node.children:
-            self._attach(child, count_ref)
+        count = 0
+        if "puzzle" not in root.properties:
+            root.properties["puzzle"] = _make_puzzle_for_node(root, self._rng)
+            count += 1
+        for child in root.children:
+            count += self.attach_puzzles(child)
+        return count
 
     def collect_puzzles(self, root: SpatialNode) -> List[Puzzle]:
-        results = []
-        self._collect(root, results)
-        return results
-
-    def _collect(self, node: SpatialNode, results: list):
-        p = node.properties.get("puzzle")
+        results: List[Puzzle] = []
+        p = root.properties.get("puzzle")
         if p:
             results.append(p)
-        for child in node.children:
-            self._collect(child, results)
+        for child in root.children:
+            results.extend(self.collect_puzzles(child))
+        return results
 
     def run_puzzle(self, puzzle: Puzzle) -> PuzzleResult:
         print(f"\n=== {puzzle.name} ({puzzle.kind.name}) ===")

--- a/puzzles/types.py
+++ b/puzzles/types.py
@@ -46,8 +46,10 @@ class Puzzle:
         return self.result
 
     def hint(self) -> Optional[str]:
-        used = min(self.attempts, len(self.hints))
-        return self.hints[used - 1] if used > 0 and self.hints else None
+        if not self.hints or self.attempts < 1:
+            return None
+        idx = min(self.attempts, len(self.hints)) - 1
+        return self.hints[idx]
 
     @property
     def solved(self) -> bool:

--- a/server/handlers.py
+++ b/server/handlers.py
@@ -5,7 +5,6 @@ import base64
 import hashlib
 import json
 import logging
-import threading
 import uuid
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
@@ -14,19 +13,18 @@ from urllib.parse import parse_qs, urlparse
 
 import causality
 import persistence
+from causality import CausalityBus, DAMPENING
 from agents.agent import Agent
 from multiverse.generator import generate_node_hierarchy
 from multiverse.node import SpatialNode
-from multiverse.utils import _build_depth_map, _count_nodes, _find_node
+from multiverse.utils import build_depth_map, count_nodes, find_node
 from puzzles.engine import PuzzleEngine
 from server.protocol import ws_recv
 from server.rooms import Player, broadcast, get_room, snapshot
 
 
 _STATIC_DIR = Path(__file__).parent.parent / "static"
-_OBSERVE_LOCK = threading.Lock()
 _log = logging.getLogger("nested_worlds")
-_DAMPENING = 0.6
 _WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 _MAX_BODY = 64 * 1024  # 64 KB
 
@@ -155,7 +153,7 @@ class Handler(BaseHTTPRequestHandler):
                 root, seed, depth, min_b, max_b = _build_world(_flatten_qs(qs))
             except ValueError as exc:
                 return self._send_error(str(exc))
-            node_count = _count_nodes(root)
+            node_count = count_nodes(root)
             persistence.save_world(seed, node_count, depth, min_b, max_b)
             self._send_json({"seed": seed, "node_count": node_count,
                              "world": _node_to_dict(root)})
@@ -310,7 +308,7 @@ class Handler(BaseHTTPRequestHandler):
             return self._send_error(str(exc))
 
         node_name = qs.get("node_name", [""])[0]
-        target    = (_find_node(root, node_name) if node_name else None) or root
+        target    = (find_node(root, node_name) if node_name else None) or root
 
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
@@ -319,11 +317,11 @@ class Handler(BaseHTTPRequestHandler):
         self._send_security_headers()
         self.end_headers()
 
-        depth_map = _build_depth_map(target)
+        depth_map = build_depth_map(target)
 
         def handler(node: SpatialNode, event: causality.CausalEvent) -> None:
             d        = depth_map.get(node.id, 0)
-            strength = round(_DAMPENING ** d, 4)
+            strength = round(DAMPENING ** d, 4)
             try:
                 self._sse_event({
                     "node":     node.name,
@@ -335,22 +333,19 @@ class Handler(BaseHTTPRequestHandler):
             except (BrokenPipeError, ConnectionResetError):
                 pass
 
-        with _OBSERVE_LOCK:
-            causality.clear_handlers()
-            causality.clear_log()
-            causality.register_handler(handler)
-            try:
-                agent = Agent(name="Observer", danger_threshold=7)
-                agent.traverse(target, max_nodes=40)
-                nodes_visited = len(agent.visited)
-                self._sse_event({"done": True, "nodes_visited": nodes_visited})
-                broadcast(get_room(seed), {"type": "agent_done", "node": target.name,
-                                           "nodes_visited": nodes_visited})
-            except (BrokenPipeError, ConnectionResetError):
-                pass
-            finally:
-                causality.clear_handlers()
-                causality.clear_log()
+        # Per-request bus keeps observation isolated from the global event
+        # stream — concurrent /observe calls no longer need to serialise.
+        bus = CausalityBus()
+        bus.register_handler(handler)
+        try:
+            agent = Agent(name="Observer", danger_threshold=7, bus=bus)
+            agent.traverse(target, max_nodes=40)
+            nodes_visited = len(agent.visited)
+            self._sse_event({"done": True, "nodes_visited": nodes_visited})
+            broadcast(get_room(seed), {"type": "agent_done", "node": target.name,
+                                       "nodes_visited": nodes_visited})
+        except (BrokenPipeError, ConnectionResetError):
+            pass
 
     # ── Puzzle ──
 
@@ -361,7 +356,7 @@ class Handler(BaseHTTPRequestHandler):
             return self._send_error(str(exc))
 
         node_name = qs.get("node_name", [""])[0]
-        target    = (_find_node(root, node_name) if node_name else None) or root
+        target    = (find_node(root, node_name) if node_name else None) or root
 
         engine  = PuzzleEngine(seed=seed)
         engine.attach_puzzles(target)
@@ -390,7 +385,7 @@ class Handler(BaseHTTPRequestHandler):
         answer      = body.get("answer", "").strip()
         attempt_raw = body.get("attempt", 1)
 
-        target = (_find_node(root, node_name) if node_name else None) or root
+        target = (find_node(root, node_name) if node_name else None) or root
 
         engine  = PuzzleEngine(seed=seed)
         engine.attach_puzzles(target)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -14,7 +14,7 @@ from interface import (
     _print_breadcrumb,
     _descend,
     _ambient_mode,
-    _build_depth_map,
+    build_depth_map,
     _play_puzzle,
     _AMBIENT_DAMPENING,
 )
@@ -120,51 +120,46 @@ class TestNavigation:
 class TestDepthMap:
     def test_root_is_depth_zero(self):
         root = make_tree()
-        dm = _build_depth_map(root)
+        dm = build_depth_map(root)
         assert dm[root.id] == 0
 
     def test_child_is_depth_one(self):
         root = make_tree()
-        dm = _build_depth_map(root)
+        dm = build_depth_map(root)
         assert dm[root.children[0].id] == 1
 
     def test_grandchild_is_depth_two(self):
         root = make_tree()
         grandchild = root.children[0].children[0]
-        dm = _build_depth_map(root)
+        dm = build_depth_map(root)
         assert dm[grandchild.id] == 2
 
     def test_all_nodes_present(self):
         root = make_tree()
-        dm = _build_depth_map(root)
+        dm = build_depth_map(root)
         assert len(dm) == 3  # root + galaxy + planet
 
 
 class TestAmbientMode:
-    def test_ambient_registers_and_clears_handler(self):
+    def test_ambient_does_not_pollute_global(self):
+        """Ambient mode runs in an isolated CausalityBus; global is untouched."""
         root = make_tree()
         with patch("builtins.input", return_value=""):
             with patch("time.sleep"):
                 _ambient_mode(root)
-        assert causality._handlers == []
+        assert causality._default._handlers == []
+        assert causality.get_log() == []
 
-    def test_ambient_fires_causal_events(self):
+    def test_ambient_fires_causal_events(self, capsys):
         root = make_tree()
-        fired: list[str] = []
-        original_register = causality.register_handler
-
-        def capturing_register(fn):
-            def wrapped(n, ev):
-                fired.append(n.name)
-                fn(n, ev)
-            original_register(wrapped)
-
-        with patch.object(causality, "register_handler", capturing_register):
-            with patch("builtins.input", return_value=""):
-                with patch("time.sleep"):
-                    _ambient_mode(root)
-
-        assert len(fired) > 0
+        with patch("builtins.input", return_value=""):
+            with patch("time.sleep"):
+                _ambient_mode(root)
+        out = capsys.readouterr().out
+        # Every tree node should appear as the agent visits it
+        assert "Aethon-1" in out
+        assert "Vela-2" in out
+        assert "Kethara-3" in out
 
     def test_ambient_clears_log_on_exit(self):
         root = make_tree()


### PR DESCRIPTION
## Summary

Medium/low-priority refactoring pass. The high-priority structural splits already landed on `main` (server/puzzle/persistence) — this PR is the follow-up cleanup. No user-visible behaviour changes.

### Highlights
- **`causality`**: module state wrapped in a `CausalityBus` class; module functions delegate to a default singleton. `/observe` and the interactive ambient mode now use **per-request buses**, eliminating the `_OBSERVE_LOCK` that previously serialised concurrent observations.
- **Real bug fix**: `agents/behaviors.transition()` previously called `should_preserve(node)` without a threshold, so agents with custom `danger_threshold` were ignored by the state machine. Threshold now threads through; `DEFAULT_DANGER_THRESHOLD` centralised.
- **`multiverse/utils`**: `_count_nodes` / `_find_node` / `_build_depth_map` renamed to public names — they were imported across modules so the leading underscore was misleading.
- **`multiverse/generator`**: per-level property generators extracted into a `_LEVEL_GENERATORS` dict, mirroring `LEVEL_POOLS` in puzzles.
- **Mutable-arg accumulators** (`count_ref=[0]`, `counter=[0]`, `results=[]`) replaced with plain recursion / `nonlocal` in `puzzles/engine.py` and `multiverse/generator.py`.
- **`_DAMPENING = 0.6`** centralised in `causality` (was duplicated in server + interface).
- Removed redundant `depth > 500` guard in `Agent` (already bounded by `max_nodes`).
- Tightened `Puzzle.hint()` bounds expression.

### Deferred / not addressed
- Item #5 (server-tracked puzzle attempt sessions). It's a behavioural change rather than a pure refactor — affects cross-session UX and multi-player semantics — so kept out of this PR pending design discussion.

## Test plan
- [x] `pytest` — 98/98 passing locally
- [x] `python main.py --seed 7 world --depth 3` — CLI smoke test
- [x] Module imports clean: `server`, `persistence`, `puzzles.engine`, `multiverse.generator`, `agents.agent`, `causality`, `interface`
- [ ] Manual server smoke (`python main.py serve`) — recommended before merge
- [ ] Confirm `/observe` SSE still streams + multiplayer room updates broadcast correctly

https://claude.ai/code/session_011XZQGge7bbZQZw7tYUDMZp