### PR TITLE
Add browser frontend, WebSocket multiplayer, and persistent agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Interaction is multi-modal: natural language for depth, visual navigation for mo
 
 ### The Hierarchy
 
-Ten nested scales, each with its own aesthetic register and causal weight:
+Eleven nested scales, each with its own aesthetic register and causal weight:
 
 ```
 Multiverse → Universe → Galaxy → Planetary System → Planet → Region → Room → Object → Molecule → Atom → SubatomicParticle
@@ -44,10 +44,13 @@ Claude-powered entities with distinct personalities, goals, and relationships to
 World state lives in a database. The multiverse exists between sessions. Interaction history, causal state, and agent memory persist. Multiple participants can be present simultaneously.
 
 **Server** (`server/`)
-Real-time API layer. WebSocket-based synchronization for multi-participant presence. Event stream for causal propagation. REST endpoints for world state queries.
+Real-time API layer. WebSocket-based synchronization for multi-participant presence and player chat, broadcasting causal events to all connected clients. REST endpoints for world state, observation, puzzles, and node speech. Serves the bundled browser UI from `/app`.
 
 **Interface** (`interface/`)
-The visual and interaction layer. Generative art that reflects world state at each scale. Multi-modal interaction: conversational, spatial, ambient. Each scale has a distinct aesthetic vocabulary.
+The terminal interaction layer. Spatial navigation, conversational `speak`, ambient observation, and embedded puzzles in a single REPL.
+
+**Frontend** (`frontend/`, `static/app/`)
+Browser clients. `frontend/` is a React + PixiJS + Vite app for scene rendering, hotspot interaction, and live multiplayer presence. `static/app/` is a vanilla D3 tree explorer served directly by the Python server. AI-generated scene backgrounds are produced via fal.ai (Flux Schnell) and cached in persistence.
 
 **Puzzles** (`puzzles/`)
 Embedded challenges that interact with the causal system. Solving a puzzle isn't just a local event — its resolution propagates. Puzzles are voiced by their containing nodes.
@@ -79,16 +82,17 @@ Human-to-human, human-to-agent, agent-to-human, agent-to-agent: all four interac
 
 | System | Status |
 |--------|--------|
-| World model (`multiverse/`) | Functional — named locations, variable branching, rich per-level properties |
-| Agent traversal (`agents/`) | Functional — FSM traversal, self-preservation, interaction logging, causal event emission |
-| Puzzle engine (`puzzles/`) | Functional — four puzzle kinds, hints, attempt tracking |
-| Causality engine (`causality/`) | Functional — event propagation with configurable dampening |
-| Persistence (`persistence/`) | Functional — SQLite world state, agent runs, puzzle results |
-| REST server (`server/`) | Functional — `/health` `/worlds` `/world` `/agent` endpoints |
-| CLI (`main.py`) | Functional — `world`, `agent`, `puzzles`, `serve`, `speak`, `history` |
-| Node consciousness (`consciousness/`) | Functional — Claude-powered node voices (requires `ANTHROPIC_API_KEY`) |
-| Tests | 78 tests across generator, agents, puzzles, persistence, causality, interface |
+| World model (`multiverse/`) | Functional — named locations, variable branching, rich per-level properties across 11 scales |
+| Agent traversal (`agents/`) | Functional — FSM traversal, self-preservation, interaction logging, causal event emission, persistent memory across runs, agent-to-agent encounters |
+| Puzzle engine (`puzzles/`) | Functional — level-specific puzzle pools across all 11 levels; server-validated attempts (no client-side leak) |
+| Causality engine (`causality/`) | Functional — event propagation with configurable dampening; events broadcast to all WebSocket clients |
+| Persistence (`persistence/`) | Functional — SQLite store for world state, agent runs, puzzle results, agent memory, node interaction history, world mutations, and scene-image cache |
+| Server (`server/`) | Functional — REST (`/health` `/worlds` `/world` `/agent` `/observe` `/puzzle` `/players` `/history` `/image` `/speak` `/puzzle/attempt`), WebSocket multiplayer at `/ws` (chat + presence + causal events), bundled browser UI at `/app`, security headers + CSP, body/frame size caps |
+| CLI (`main.py`) | Functional — `world`, `agent`, `puzzles`, `play`, `serve`, `speak`, `history` |
+| Node consciousness (`consciousness/`) | Functional — Claude-powered node voices, fed by per-node interaction history (requires `ANTHROPIC_API_KEY`) |
 | Interface (`interface/`) | Functional — interactive terminal session (spatial, conversational, ambient) |
+| Frontend (`frontend/`) | Functional — React + PixiJS + Vite client wired to the WebSocket server; fal.ai-generated scene backgrounds |
+| Tests | 116 tests across generator, agents, puzzles, persistence, causality, interface, consciousness, and HTTP/WebSocket server |
 
 ---
 
@@ -101,11 +105,27 @@ pip install anthropic
 # Install with dev dependencies (for tests)
 pip install -e ".[dev]"
 
-# Set your Anthropic API key (only required for the `speak` command)
-export ANTHROPIC_API_KEY=sk-ant-...
+# Copy the environment template and fill in keys you need
+cp .env.example .env
+```
 
-# Override the Claude model (optional, defaults to claude-opus-4-7)
-export NESTED_WORLDS_MODEL=claude-sonnet-4-6
+Environment variables (see `.env.example`):
+
+| Variable | Required for | Default |
+|----------|--------------|---------|
+| `ANTHROPIC_API_KEY` | Node consciousness (`speak`, browser chat with nodes) | — |
+| `NESTED_WORLDS_MODEL` | Override the Claude model | `claude-opus-4-7` |
+| `FAL_KEY` | AI-generated scene backgrounds (Flux Schnell) | optional |
+| `REDIS_URL` | Scene cache + session state | optional |
+| `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, `R2_PUBLIC_URL` | Generated image storage | optional |
+
+The browser frontend (`frontend/`) is a separate Vite project:
+
+```bash
+cd frontend
+npm install
+npm run dev    # dev server with hot reload
+npm run build  # production bundle
 ```
 
 ## Running Locally

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,36 @@ All notable changes to this project are documented here.
 ## [Unreleased]
 
 ### Added
+- **Browser frontend** (`frontend/`): React + PixiJS + Vite client wired to the WebSocket server. AI-generated scene backgrounds via fal.ai (Flux Schnell), cached in persistence
+- **WebSocket multiplayer** (`server/`): `/ws` endpoint with presence, player-to-player chat, ping/keepalive, and broadcast of causal events to all connected clients
+- **Persistent agent memory** (`agents/`, `persistence/`): agents remember visited nodes across runs; `save_agent_memory` / `load_agent_memory` / `list_agent_memories`
+- **Agent-to-agent encounters** (`agents/`): when traversing agents meet, encounter events are emitted into the causal bus
+- **Interaction-history-aware consciousness** (`consciousness/`): per-node history from `persistence.get_node_history` is injected into the prompt so nodes reference past visitors
+- **Browser UI** (`static/app/`): vanilla D3 tree explorer mounted at `/app`; supports Observe and Puzzle actions
+- **Easter eggs**: hidden routes under `/easter-egg/` (Konami code, illusion page)
+- **Server module split** (`server/handlers.py`, `protocol.py`, `rooms.py`) and HTTP server integration tests
 - **Interactive interface** (`interface/`): `run_session()` brings the world to life as a playable terminal session. Three interaction modes in a single REPL:
   - *Spatial* — navigate the hierarchy with `go <N>` / `up`; each scale level rendered in a distinct ANSI colour
   - *Conversational* — `speak [message]` routes to the consciousness module (Claude); unrecognised input is forwarded as a speak message
   - *Ambient* — `observe` runs an agent traversal from the current node with live causal-event output (node name, event kind, dampened strength bar)
   - `map` prints an ASCII subtree (3 levels deep); `puzzle` drops into the puzzle engine at the current location
 - **`play` CLI subcommand** (`main.py`): `python main.py play [--depth N] [--min-breadth N] [--max-breadth N]`
-- **16 interface tests** (`tests/test_interface.py`): formatting, navigation, ambient mode, puzzle integration
+- **Architecture decision records** (`docs/decisions/`): ADR-001 (frontend stack), ADR-002 (image generation); Phase 1 beta scope (`docs/roadmap/`); game design doc (`docs/design/`); infrastructure stack (`docs/infrastructure/`)
+- **`multiverse/utils.py`**: `count_nodes`, `find_node`, `build_depth_map` extracted from scattered call sites
+- Test suite expanded to **116 tests** (HTTP server integration, WebSocket frame parsing, consciousness thread-safety, persistence, interface, etc.)
+
+### Changed
+- **Puzzle system**: reworked into level-specific pools across all 11 hierarchy levels; attempts validated on the server (no client-controlled answer leak)
+- **REST endpoints** added: `/observe`, `/puzzle`, `/players`, `/history`, `/image`, `POST /speak`, `POST /puzzle/attempt`
+- Default server bind host changed to `127.0.0.1` (was `0.0.0.0`)
+- `persistence/` no longer exposes a noisy boilerplate decorator; surface API simplified
+
+### Security
+- CSP and security headers (`X-Frame-Options`, `Referrer-Policy`, etc.) on all responses
+- `escHtml` applied to every `innerHTML` insertion in the browser UI
+- POST body size cap and WebSocket frame size limit
+- Sanitised `/speak` inputs and thread-safe Anthropic client initialisation
+- Puzzle attempt counter moved server-side
 
 
 ### Changed

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -45,35 +45,49 @@ A shared persistent multiverse inhabited simultaneously by human players and AI 
 - **`generator.py`** — deterministic PCG with named locations, variable branching, and level-specific property templates
 
 ### `consciousness/` — Node Voice Layer
-Claude-powered persona system. Each node's voice is seeded by its properties and interaction history. Nodes respond in character, reference past visitors, and hold perspective. Planned components:
-- `persona.py` — maps node properties to Claude system prompts
-- `memory.py` — per-node interaction history
-- `voice.py` — conversation handler (Claude API integration)
+Claude-powered persona system. Each node's voice is seeded by its properties and accumulated interaction history. Nodes respond in character, reference past visitors, and hold perspective.
+- `speak(node, message, history)` — conversational handler; injects per-node history into the system prompt
+- `describe(node, history)` — short in-character self-description for ambient/look output
+- Thread-safe lazy `Anthropic` client init; sanitises inbound message text
 
 ### `causality/` — Causal Engine
-Propagation system for cross-scale effects. Actions register as events; consequences travel up and down the hierarchy with dampening and delay. Planned components:
-- `event.py` — causal event data model
-- `propagation.py` — hierarchy traversal with dampening
-- `registry.py` — event log and state tracking
+Propagation system for cross-scale effects. Actions register as events; consequences travel up and down the hierarchy with dampening and delay.
+- `EventKind`, `CausalEvent` — event taxonomy and data model
+- `CausalityBus` — handler registry and event log
+- `emit(...)`, `propagate(...)` — local emission and hierarchy traversal with depth-based dampening
+- Wired into the WebSocket server: emitted events fan out to all connected clients
 
 ### `agents/` — AI Agent System
-- **`agent.py`** — `Agent` dataclass with FSM traversal, self-preservation logic, interaction logging
+- **`agent.py`** — `Agent` dataclass with FSM traversal, self-preservation logic, interaction logging, persistent memory across runs, and agent-to-agent encounter handling
 - **`behaviors.py`** — `State` enum, `transition()` function, behavioral predicates
-- Planned: `persona.py` for Claude-powered agent personalities with goals and memory
 
 ### `persistence/` — World State
-Planned: database layer for persistent world state, node history, agent memory, and causal event log. Enables the world to exist between sessions and across multiple simultaneous participants.
+SQLite-backed store. Enables the world to exist between sessions and across multiple simultaneous participants.
+- `save_world` / `list_worlds` — generation parameters and node counts
+- `save_agent_run` / `get_agent_runs` — per-run traversal events
+- `save_agent_memory` / `load_agent_memory` / `list_agent_memories` — persistent agent knowledge of visited nodes
+- `record_mutation` / `get_mutations` — world-state changes from interaction
+- `get_node_history` — interaction transcript per node, fed back into consciousness prompts
+- `cache_image` / `get_cached_image` — scene-image cache keyed by node signature
+- `save_puzzle_result` — server-side puzzle outcome record
 
 ### `server/` — API Layer
-Planned: real-time API for multi-participant synchronization. WebSocket event stream for causal propagation and presence. REST endpoints for world state queries.
+Threaded `http.server` with REST + WebSocket support, security headers (CSP, X-Frame-Options, etc.), and POST/frame size caps.
+- **REST**: `/health`, `/worlds`, `/world`, `/players`, `/history`, `/agent`, `/observe`, `/puzzle`, `/image`, plus `POST /speak` and `POST /puzzle/attempt`
+- **WebSocket** (`/ws`): presence, player-to-player chat, broadcast of causal events, ping/keepalive
+- **Static**: bundled D3 browser UI mounted at `/app`; easter-egg routes under `/easter-egg/`
+- Module split: `handlers.py` (HTTP/WebSocket dispatch), `protocol.py` (frame parsing), `rooms.py` (presence)
 
-### `interface/` — Visual & Interaction Layer
-Planned: generative visual art responsive to world state. Multi-modal interaction (conversational, spatial, ambient). Distinct aesthetic vocabulary per scale level.
+### `interface/` — Terminal Interaction Layer
+Interactive terminal session (`run_session`) with three modes — spatial (`go`/`up`/`map`), conversational (`speak`), and ambient (`observe`) — plus inline puzzles. Each scale level renders in a distinct ANSI colour.
+
+### `frontend/` — Browser Client
+React + PixiJS + Vite app that talks to the WebSocket server. Renders fal.ai-generated scene backgrounds, hotspot interactions, multiplayer presence, and live causal-event ripples. A complementary vanilla D3 tree explorer is served from `static/app/`.
 
 ### `puzzles/` — Embedded Challenges
 - **`types.py`** — `Puzzle` dataclass (kind, attempts, hints, result)
 - **`engine.py`** — `PuzzleEngine`: attach, collect, run puzzles interactively
-- Planned: causal integration — puzzle resolution propagates as causal events
+- Level-specific puzzle pools across all 11 hierarchy levels; server validates attempts so the answer never leaves the server
 
 ---
 


### PR DESCRIPTION
## Summary
This PR introduces a complete browser-based frontend with real-time multiplayer support, persistent agent memory across runs, and interaction-history-aware node consciousness. The server gains WebSocket support for presence and causal event broadcasting, while the puzzle system is reworked into level-specific pools with server-side validation.

## Key Changes

### Frontend & UI
- **Browser frontend** (`frontend/`): React + PixiJS + Vite client wired to WebSocket server with AI-generated scene backgrounds via fal.ai (Flux Schnell), cached in persistence
- **Vanilla D3 tree explorer** (`static/app/`): mounted at `/app`, supports Observe and Puzzle actions
- **Easter egg routes** under `/easter-egg/` (Konami code, illusion page)

### Server & Multiplayer
- **WebSocket endpoint** (`/ws`): presence tracking, player-to-player chat, ping/keepalive, and broadcast of causal events to all connected clients
- **New REST endpoints**: `/observe`, `/puzzle`, `/players`, `/history`, `/image`, `POST /speak`, `POST /puzzle/attempt`
- **Server module refactor**: split into `handlers.py` (HTTP/WebSocket dispatch), `protocol.py` (frame parsing), `rooms.py` (presence management)
- **Security hardening**: CSP and security headers on all responses, POST/frame size caps, sanitised inputs, thread-safe Anthropic client init

### Agent & Persistence
- **Persistent agent memory**: agents now remember visited nodes across runs via `save_agent_memory` / `load_agent_memory` / `list_agent_memories`
- **Agent-to-agent encounters**: when traversing agents meet, encounter events are emitted into the causal bus
- **Interaction-history-aware consciousness**: per-node history from `persistence.get_node_history` is injected into Claude prompts so nodes reference past visitors
- **Scene image cache**: `cache_image` / `get_cached_image` in persistence for fal.ai-generated backgrounds

### Puzzle System
- Reworked into **level-specific puzzle pools** across all 11 hierarchy levels
- **Server-side validation**: puzzle attempts validated on the server (no client-controlled answer leak)
- Attempt counter moved server-side

### Documentation & Testing
- **Architecture decision records** (`docs/decisions/`): ADR-001 (frontend stack), ADR-002 (image generation)
- **Phase 1 beta scope** and **game design doc** added
- **Test suite expanded** to 116 tests (HTTP server integration, WebSocket frame parsing, consciousness thread-safety, persistence, interface, etc.)

### Hierarchy Update
- Updated from 10 to **11 nested scales** (added SubatomicParticle level)

## Implementation Details
- The hierarchy now spans: Multiverse → Universe → Galaxy → Planetary System → Planet → Region → Room → Object → Molecule → Atom → SubatomicParticle
- WebSocket events fan out to all connected clients, enabling real-time causal propagation across multiplayer sessions
- Scene backgrounds are generated via fal.ai (Flux Schnell) and cached to avoid repeated API calls
- The terminal interface (`interface/`) remains functional alongside the new browser UI
- Default server bind host changed to `127.0.0.1` for security (was `0.0.0.0`)

https://claude.ai/code/session_01TohDgt1Z4XTrrn9hF37jEw