### PR TITLE
docs: align README, architecture, and ADRs with current state; close ADR-002 cache-invalidation gap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,15 +2,5 @@
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 NESTED_WORLDS_MODEL=claude-opus-4-7
 
-# fal.ai — AI scene image generation (Flux Schnell)
+# fal.ai — AI scene image generation (fal-ai/fast-sdxl)
 FAL_KEY=your_fal_api_key_here
-
-# Redis — scene hash cache and session state
-REDIS_URL=redis://localhost:6379/0
-
-# Cloudflare R2 — generated image storage
-R2_ACCOUNT_ID=your_cloudflare_account_id
-R2_ACCESS_KEY_ID=your_r2_access_key_id
-R2_SECRET_ACCESS_KEY=your_r2_secret_access_key
-R2_BUCKET=nested-worlds-scenes
-R2_PUBLIC_URL=https://your-r2-public-url.r2.dev

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Interaction is multi-modal: natural language for depth, visual navigation for mo
 
 ### The Hierarchy
 
-Ten nested scales, each with its own aesthetic register and causal weight:
+Eleven nested scales, each with its own aesthetic register and causal weight:
 
 ```
 Multiverse → Universe → Galaxy → Planetary System → Planet → Region → Room → Object → Molecule → Atom → SubatomicParticle
@@ -44,10 +44,13 @@ Claude-powered entities with distinct personalities, goals, and relationships to
 World state lives in a database. The multiverse exists between sessions. Interaction history, causal state, and agent memory persist. Multiple participants can be present simultaneously.
 
 **Server** (`server/`)
-Real-time API layer. WebSocket-based synchronization for multi-participant presence. Event stream for causal propagation. REST endpoints for world state queries.
+Real-time API layer. WebSocket-based synchronization for multi-participant presence and player chat, broadcasting causal events to all connected clients. REST endpoints for world state, observation, puzzles, and node speech. Serves the bundled browser UI from `/app`.
 
 **Interface** (`interface/`)
-The visual and interaction layer. Generative art that reflects world state at each scale. Multi-modal interaction: conversational, spatial, ambient. Each scale has a distinct aesthetic vocabulary.
+The terminal interaction layer. Spatial navigation, conversational `speak`, ambient observation, and embedded puzzles in a single REPL.
+
+**Frontend** (`frontend/`, `static/app/`)
+Browser clients. `frontend/` is a React + PixiJS + Vite app for scene rendering, hotspot interaction, and live multiplayer presence. `static/app/` is a vanilla D3 tree explorer served directly by the Python server. AI-generated scene backgrounds are produced via fal.ai (Flux Schnell) and cached in persistence.
 
 **Puzzles** (`puzzles/`)
 Embedded challenges that interact with the causal system. Solving a puzzle isn't just a local event — its resolution propagates. Puzzles are voiced by their containing nodes.
@@ -79,16 +82,17 @@ Human-to-human, human-to-agent, agent-to-human, agent-to-agent: all four interac
 
 | System | Status |
 |--------|--------|
-| World model (`multiverse/`) | Functional — named locations, variable branching, rich per-level properties |
-| Agent traversal (`agents/`) | Functional — FSM traversal, self-preservation, interaction logging, causal event emission |
-| Puzzle engine (`puzzles/`) | Functional — four puzzle kinds, hints, attempt tracking |
-| Causality engine (`causality/`) | Functional — event propagation with configurable dampening |
-| Persistence (`persistence/`) | Functional — SQLite world state, agent runs, puzzle results |
-| REST server (`server/`) | Functional — `/health` `/worlds` `/world` `/agent` endpoints |
-| CLI (`main.py`) | Functional — `world`, `agent`, `puzzles`, `serve`, `speak`, `history` |
-| Node consciousness (`consciousness/`) | Functional — Claude-powered node voices (requires `ANTHROPIC_API_KEY`) |
-| Tests | 78 tests across generator, agents, puzzles, persistence, causality, interface |
+| World model (`multiverse/`) | Functional — named locations, variable branching, rich per-level properties across 11 scales |
+| Agent traversal (`agents/`) | Functional — FSM traversal, self-preservation, interaction logging, causal event emission, persistent memory across runs, agent-to-agent encounters |
+| Puzzle engine (`puzzles/`) | Functional — level-specific puzzle pools across all 11 levels; server-validated attempts (no client-side leak) |
+| Causality engine (`causality/`) | Functional — event propagation with configurable dampening; events broadcast to all WebSocket clients |
+| Persistence (`persistence/`) | Functional — SQLite store for world state, agent runs, puzzle results, agent memory, node interaction history, world mutations, and scene-image cache |
+| Server (`server/`) | Functional — REST (`/health` `/worlds` `/world` `/agent` `/observe` `/puzzle` `/players` `/history` `/image` `/speak` `/puzzle/attempt`), WebSocket multiplayer at `/ws` (chat + presence + causal events), bundled browser UI at `/app`, security headers + CSP, body/frame size caps |
+| CLI (`main.py`) | Functional — `world`, `agent`, `puzzles`, `play`, `serve`, `speak`, `history` |
+| Node consciousness (`consciousness/`) | Functional — Claude-powered node voices, fed by per-node interaction history (requires `ANTHROPIC_API_KEY`) |
 | Interface (`interface/`) | Functional — interactive terminal session (spatial, conversational, ambient) |
+| Frontend (`frontend/`) | Functional — React + PixiJS + Vite client wired to the WebSocket server; fal.ai-generated scene backgrounds |
+| Tests | 116 tests across generator, agents, puzzles, persistence, causality, interface, consciousness, and HTTP/WebSocket server |
 
 ---
 
@@ -101,11 +105,27 @@ pip install anthropic
 # Install with dev dependencies (for tests)
 pip install -e ".[dev]"
 
-# Set your Anthropic API key (only required for the `speak` command)
-export ANTHROPIC_API_KEY=sk-ant-...
+# Copy the environment template and fill in keys you need
+cp .env.example .env
+```
 
-# Override the Claude model (optional, defaults to claude-opus-4-7)
-export NESTED_WORLDS_MODEL=claude-sonnet-4-6
+Environment variables (see `.env.example`):
+
+| Variable | Required for | Default |
+|----------|--------------|---------|
+| `ANTHROPIC_API_KEY` | Node consciousness (`speak`, browser chat with nodes) | — |
+| `NESTED_WORLDS_MODEL` | Override the Claude model | `claude-opus-4-7` |
+| `FAL_KEY` | AI-generated scene backgrounds (Flux Schnell) | optional |
+| `REDIS_URL` | Scene cache + session state | optional |
+| `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, `R2_PUBLIC_URL` | Generated image storage | optional |
+
+The browser frontend (`frontend/`) is a separate Vite project:
+
+```bash
+cd frontend
+npm install
+npm run dev    # dev server with hot reload
+npm run build  # production bundle
 ```
 
 ## Running Locally

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,13 +7,36 @@ All notable changes to this project are documented here.
 ## [Unreleased]
 
 ### Added
+- **Browser frontend** (`frontend/`): React + PixiJS + Vite client wired to the WebSocket server. AI-generated scene backgrounds via fal.ai (Flux Schnell), cached in persistence
+- **WebSocket multiplayer** (`server/`): `/ws` endpoint with presence, player-to-player chat, ping/keepalive, and broadcast of causal events to all connected clients
+- **Persistent agent memory** (`agents/`, `persistence/`): agents remember visited nodes across runs; `save_agent_memory` / `load_agent_memory` / `list_agent_memories`
+- **Agent-to-agent encounters** (`agents/`): when traversing agents meet, encounter events are emitted into the causal bus
+- **Interaction-history-aware consciousness** (`consciousness/`): per-node history from `persistence.get_node_history` is injected into the prompt so nodes reference past visitors
+- **Browser UI** (`static/app/`): vanilla D3 tree explorer mounted at `/app`; supports Observe and Puzzle actions
+- **Easter eggs**: hidden routes under `/easter-egg/` (Konami code, illusion page)
+- **Server module split** (`server/handlers.py`, `protocol.py`, `rooms.py`) and HTTP server integration tests
 - **Interactive interface** (`interface/`): `run_session()` brings the world to life as a playable terminal session. Three interaction modes in a single REPL:
   - *Spatial* — navigate the hierarchy with `go <N>` / `up`; each scale level rendered in a distinct ANSI colour
   - *Conversational* — `speak [message]` routes to the consciousness module (Claude); unrecognised input is forwarded as a speak message
   - *Ambient* — `observe` runs an agent traversal from the current node with live causal-event output (node name, event kind, dampened strength bar)
   - `map` prints an ASCII subtree (3 levels deep); `puzzle` drops into the puzzle engine at the current location
 - **`play` CLI subcommand** (`main.py`): `python main.py play [--depth N] [--min-breadth N] [--max-breadth N]`
-- **16 interface tests** (`tests/test_interface.py`): formatting, navigation, ambient mode, puzzle integration
+- **Architecture decision records** (`docs/decisions/`): ADR-001 (frontend stack), ADR-002 (image generation); Phase 1 beta scope (`docs/roadmap/`); game design doc (`docs/design/`); infrastructure stack (`docs/infrastructure/`)
+- **`multiverse/utils.py`**: `count_nodes`, `find_node`, `build_depth_map` extracted from scattered call sites
+- Test suite expanded to **116 tests** (HTTP server integration, WebSocket frame parsing, consciousness thread-safety, persistence, interface, etc.)
+
+### Changed
+- **Puzzle system**: reworked into level-specific pools across all 11 hierarchy levels; attempts validated on the server (no client-controlled answer leak)
+- **REST endpoints** added: `/observe`, `/puzzle`, `/players`, `/history`, `/image`, `POST /speak`, `POST /puzzle/attempt`
+- Default server bind host changed to `127.0.0.1` (was `0.0.0.0`)
+- `persistence/` no longer exposes a noisy boilerplate decorator; surface API simplified
+
+### Security
+- CSP and security headers (`X-Frame-Options`, `Referrer-Policy`, etc.) on all responses
+- `escHtml` applied to every `innerHTML` insertion in the browser UI
+- POST body size cap and WebSocket frame size limit
+- Sanitised `/speak` inputs and thread-safe Anthropic client initialisation
+- Puzzle attempt counter moved server-side
 
 
 ### Changed

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -45,35 +45,49 @@ A shared persistent multiverse inhabited simultaneously by human players and AI 
 - **`generator.py`** — deterministic PCG with named locations, variable branching, and level-specific property templates
 
 ### `consciousness/` — Node Voice Layer
-Claude-powered persona system. Each node's voice is seeded by its properties and interaction history. Nodes respond in character, reference past visitors, and hold perspective. Planned components:
-- `persona.py` — maps node properties to Claude system prompts
-- `memory.py` — per-node interaction history
-- `voice.py` — conversation handler (Claude API integration)
+Claude-powered persona system. Each node's voice is seeded by its properties and accumulated interaction history. Nodes respond in character, reference past visitors, and hold perspective.
+- `speak(node, message, history)` — conversational handler; injects per-node history into the system prompt
+- `describe(node, history)` — short in-character self-description for ambient/look output
+- Thread-safe lazy `Anthropic` client init; sanitises inbound message text
 
 ### `causality/` — Causal Engine
-Propagation system for cross-scale effects. Actions register as events; consequences travel up and down the hierarchy with dampening and delay. Planned components:
-- `event.py` — causal event data model
-- `propagation.py` — hierarchy traversal with dampening
-- `registry.py` — event log and state tracking
+Propagation system for cross-scale effects. Actions register as events; consequences travel up and down the hierarchy with dampening and delay.
+- `EventKind`, `CausalEvent` — event taxonomy and data model
+- `CausalityBus` — handler registry and event log
+- `emit(...)`, `propagate(...)` — local emission and hierarchy traversal with depth-based dampening
+- Wired into the WebSocket server: emitted events fan out to all connected clients
 
 ### `agents/` — AI Agent System
-- **`agent.py`** — `Agent` dataclass with FSM traversal, self-preservation logic, interaction logging
+- **`agent.py`** — `Agent` dataclass with FSM traversal, self-preservation logic, interaction logging, persistent memory across runs, and agent-to-agent encounter handling
 - **`behaviors.py`** — `State` enum, `transition()` function, behavioral predicates
-- Planned: `persona.py` for Claude-powered agent personalities with goals and memory
 
 ### `persistence/` — World State
-Planned: database layer for persistent world state, node history, agent memory, and causal event log. Enables the world to exist between sessions and across multiple simultaneous participants.
+SQLite-backed store. Enables the world to exist between sessions and across multiple simultaneous participants.
+- `save_world` / `list_worlds` — generation parameters and node counts
+- `save_agent_run` / `get_agent_runs` — per-run traversal events
+- `save_agent_memory` / `load_agent_memory` / `list_agent_memories` — persistent agent knowledge of visited nodes
+- `record_mutation` / `get_mutations` — world-state changes from interaction
+- `get_node_history` — interaction transcript per node, fed back into consciousness prompts
+- `cache_image` / `get_cached_image` — scene-image cache keyed by node signature
+- `save_puzzle_result` — server-side puzzle outcome record
 
 ### `server/` — API Layer
-Planned: real-time API for multi-participant synchronization. WebSocket event stream for causal propagation and presence. REST endpoints for world state queries.
+Threaded `http.server` with REST + WebSocket support, security headers (CSP, X-Frame-Options, etc.), and POST/frame size caps.
+- **REST**: `/health`, `/worlds`, `/world`, `/players`, `/history`, `/agent`, `/observe`, `/puzzle`, `/image`, plus `POST /speak` and `POST /puzzle/attempt`
+- **WebSocket** (`/ws`): presence, player-to-player chat, broadcast of causal events, ping/keepalive
+- **Static**: bundled D3 browser UI mounted at `/app`; easter-egg routes under `/easter-egg/`
+- Module split: `handlers.py` (HTTP/WebSocket dispatch), `protocol.py` (frame parsing), `rooms.py` (presence)
 
-### `interface/` — Visual & Interaction Layer
-Planned: generative visual art responsive to world state. Multi-modal interaction (conversational, spatial, ambient). Distinct aesthetic vocabulary per scale level.
+### `interface/` — Terminal Interaction Layer
+Interactive terminal session (`run_session`) with three modes — spatial (`go`/`up`/`map`), conversational (`speak`), and ambient (`observe`) — plus inline puzzles. Each scale level renders in a distinct ANSI colour.
+
+### `frontend/` — Browser Client
+React + PixiJS + Vite app that talks to the WebSocket server. Renders fal.ai-generated scene backgrounds, hotspot interactions, multiplayer presence, and live causal-event ripples. A complementary vanilla D3 tree explorer is served from `static/app/`.
 
 ### `puzzles/` — Embedded Challenges
 - **`types.py`** — `Puzzle` dataclass (kind, attempts, hints, result)
 - **`engine.py`** — `PuzzleEngine`: attach, collect, run puzzles interactively
-- Planned: causal integration — puzzle resolution propagates as causal events
+- Level-specific puzzle pools across all 11 hierarchy levels; server validates attempts so the answer never leaves the server
 
 ---
 

--- a/docs/decisions/ADR-001-frontend-stack.md
+++ b/docs/decisions/ADR-001-frontend-stack.md
@@ -1,38 +1,76 @@
-# ADR-001: Frontend Stack Selection
+# ADR-001: Stack Selection
 
-**Status:** Decided
+**Status:** Revised 2026-05-03 — implementation diverged from the original decision; this revision records what actually shipped and the triggers for revisiting.
 
 ---
 
 ## Context
 
-Nested World Adventure requires a multiplayer-capable frontend for a multiverse node-traversal game. Two hard constraints shape every choice:
+Nested Worlds Adventure requires a multiplayer-capable client and server for a multiverse node-traversal game. Two hard constraints shape every choice:
 
 - **Solo dev** — fast path to beta, minimal operational surface
 - **Budget** — minimal infrastructure cost, preference for free tiers and pay-as-you-go
 
 ---
 
-## Decision
+## Decision (as built)
 
-**React + PixiJS + FastAPI WebSockets + fal.ai (Flux Schnell) + Redis + Cloudflare R2**
+**React + PixiJS (Vite) + Python stdlib `http.server` with hand-rolled WebSocket + fal.ai + SQLite**
 
----
-
-## Rationale
-
-| Component | Role |
-|-----------|------|
-| React | All non-game UI: lobbies, text panels, node history, player presence indicators |
-| PixiJS | Scene rendering, hotspot detection, pan interaction within nodes |
-| FastAPI WebSockets | Real-time multiplayer — Python-primary, no new runtime required |
-| fal.ai Flux Schnell | AI scene generation (~$0.003/image), pay-as-you-go |
-| Redis | Scene hash caching and regeneration threshold tracking |
-| Cloudflare R2 | Image storage — free tier 10 GB, zero egress cost |
+| Component | Role | Notes |
+|-----------|------|-------|
+| React + Vite | All non-game UI: lobbies, text panels, node history, player presence indicators | `frontend/` |
+| PixiJS | Scene rendering, hotspot detection, pan interaction within nodes | `frontend/src/` |
+| Python stdlib `http.server` + `ThreadingMixIn` | Threaded HTTP server, REST endpoints, static file serving | `server/__init__.py`, `server/handlers.py` |
+| Hand-rolled WebSocket (`struct`) | Real-time multiplayer: presence, chat, causal-event broadcast | `server/protocol.py`, `server/rooms.py` |
+| fal.ai (`fal-ai/fast-sdxl` via `urllib`) | AI scene generation, pay-as-you-go | `server/handlers.py:/image` |
+| SQLite (`persistence/`) | Scene-image cache, world state, agent memory, node history, mutations | `persistence/__init__.py` |
 
 ---
 
-## Rejected Alternatives
+## Why this diverges from the original decision
+
+The original ADR named **FastAPI WebSockets**, **Redis** (scene cache), **Cloudflare R2** (image storage), and **Flux Schnell**. None of those shipped:
+
+- **FastAPI → stdlib `http.server`.** The original rationale was "Python-primary, no new runtime required." The stdlib choice honors that constraint *more strictly* — zero new runtime dependencies (no uvicorn/hypercorn). With ~780 lines of server code, 116 tests passing, and security headers / body and frame size caps already in place, the stdlib server has met every Phase 1 requirement.
+- **Redis / R2 → SQLite.** A single SQLite database now handles world state, agent runs, agent memory, node history, world mutations, *and* the scene-image cache. One persistence layer beats three for solo dev. R2 may still be relevant if image volume grows beyond local disk.
+- **Flux Schnell → fast-sdxl.** Cost per image is comparable; the model swap is incidental. ADR-002 should be updated to match.
+
+Net effect: fewer moving parts than the original decision, same capability surface for Phase 1.
+
+---
+
+## Trade-offs accepted
+
+The stdlib + hand-rolled WebSocket choice carries known costs:
+
+- **Thread-per-connection scaling.** `ThreadingMixIn` allocates one OS thread per open WebSocket. Fine for tens of concurrent players; problematic at hundreds.
+- **Hand-rolled WebSocket protocol.** `server/protocol.py` covers the subset we use (text frames, ping). Fragmentation, compression, backpressure, and edge cases are ours to maintain.
+- **`http.server` is "not recommended for production"** by the Python docs. Mitigations in place: CSP and security headers, body/frame size caps, thread-safe Anthropic client init, sanitised inputs, server-side puzzle validation.
+- **No Pydantic / OpenAPI.** Validation is hand-rolled; no auto-generated API docs.
+
+These are acceptable for the current scale and team size.
+
+---
+
+## Revisit when…
+
+Migrate to FastAPI (or similar async framework) when *any* of the following becomes true:
+
+- Concurrent WebSocket clients consistently exceed ~100, or thread count becomes a host-resource concern
+- A new feature requires WebSocket fragmentation, per-message compression, or non-trivial backpressure handling
+- Validation / OpenAPI / dependency-injection benefits begin to outweigh migration cost (e.g., an external API consumer ships against the server)
+- The hand-rolled protocol code accumulates more than one bug per quarter
+- Authentication / session management beyond the current presence model is needed
+
+Migrate from SQLite-only persistence when:
+
+- Scene-image cache volume exceeds practical local-disk limits → introduce R2
+- Multi-process or multi-host deployment is required → introduce Redis or equivalent
+
+---
+
+## Rejected Alternatives (frontend rendering)
 
 **Phaser.js** — Overkill for a point-and-click interaction model. Adds physics and sprite overhead that the game does not need.
 

--- a/docs/decisions/ADR-002-image-generation.md
+++ b/docs/decisions/ADR-002-image-generation.md
@@ -1,55 +1,124 @@
 # ADR-002: Image Generation Architecture
 
-**Status:** Decided
+**Status:** Revised 2026-05-03 — implementation diverged from the original decision; this revision records what shipped, what is deliberately deferred, and what remains an unmet Phase 1 commitment.
 
 ---
 
 ## Phase 1 Approach: Prompt Engineering Only
 
-No IP-Adapter or LoRA conditioning at beta. Consistency is achieved through structured prompt templates and node-ID-seeded randomness. Thematic coherence is sufficient for Phase 1 — pixel-perfect consistency is neither required nor desirable given that style drift is a core mechanic.
+No IP-Adapter or LoRA conditioning at beta. Consistency is achieved through structured prompt templates and node-ID-seeded randomness. Thematic coherence is sufficient for Phase 1 — pixel-perfect consistency is neither required nor desirable given that style drift is a core mechanic. **This still holds.**
 
 ---
 
-## Prompt Assembly (Python)
+## Prompt Assembly (as built)
 
-Scene prompts are programmatically assembled from node state:
+Currently in `server/handlers.py::_do_image`:
 
 ```python
-def build_prompt(node):
-    base_style = HIERARCHY_STYLES[node.level]
-    property_modifiers = get_style_modifiers(node)  # from property matrix
-    evolution_weight = node.ripple_score             # 0.0–1.0
-    history_marks = node.interaction_summary         # "conflict", "cooperation", etc.
-    return (
-        f"{base_style}, {property_modifiers}, {history_marks}, "
-        "cinematic composition, depth of field, no text, no UI elements"
-    )
+prop_summary = ", ".join(f"{k}: {v}" for k, v in list(node_props.items())[:6])
+prompt = (
+    f"A {node_level.lower()} in a nested multiverse sci-fi world. "
+    f"{prop_summary}. "
+    "Cinematic lighting, intricate detail, deep space aesthetic, "
+    "dark palette with bioluminescent accents."
+)
 ```
 
----
+This is a thinner version of what the original ADR prescribed. It produces serviceable images but does not yet incorporate per-level style baselines (`HIERARCHY_STYLES`), structured property modifiers, `ripple_score` weighting, or `interaction_summary` history marks. The node fields exist (`multiverse/node.py:21-22`) and are wired into the world model — just not into prompt assembly.
 
-## Caching Strategy
-
-| Step | Detail |
-|------|--------|
-| Generate | Once on node discovery |
-| Cache | Scene hash in Redis, keyed to `node_id` |
-| Invalidate | When `ripple_score` shift exceeds regeneration threshold (default: `> 0.3`) |
-| Store | Cloudflare R2 as `.webp` |
+Acceptable for Phase 1 beta; richer assembly is a near-term enhancement, not a blocker.
 
 ---
 
-## Cost Model
+## Generation Backend (as built)
+
+| Aspect | Decision (original) | As built |
+|--------|--------------------|----------|
+| Provider | fal.ai | fal.ai ✓ |
+| Model | Flux Schnell | `fal-ai/fast-sdxl` |
+| Steps | — | `num_inference_steps: 4` |
+| Size | — | `landscape_4_3` |
+| Transport | — | `urllib` (no SDK dependency) |
+
+The model swap to `fast-sdxl` is incidental — comparable cost and quality; revisit only if image quality becomes a complaint.
+
+---
+
+## Caching Strategy (as built)
+
+| Step | As built | Original prescription | Status |
+|------|----------|-----------------------|--------|
+| Generate | Once per `(seed, node_id)` | Once on node discovery | ✓ matches intent |
+| Cache | SQLite (`persistence.cache_image`), keyed to `f"{seed}:{node_id}"` | Redis hash, keyed to `node_id` | Backend swap — see "Why" |
+| Invalidate | Never | When `ripple_score` shift > 0.3 | **Not implemented — see "Unmet Phase 1 commitments"** |
+| Store | fal.ai-hosted URL (string in SQLite) | Cloudflare R2 as `.webp` | Backend swap — see "Why" |
+
+---
+
+## Why this diverges from the original decision
+
+- **Redis → SQLite.** A single SQLite database now handles all persistence (world state, agent memory, node history, mutations, *and* image cache). Solo dev benefits from one persistence layer. Redis is preserved as a future option once multi-process or multi-host deployment is required.
+- **Cloudflare R2 .webp → fal.ai-hosted URLs.** We currently cache the URL fal.ai returns rather than re-hosting the image. This is cheaper (no R2 bucket, no transcode, no egress accounting) and ships faster, but couples us to fal.ai URL lifetime — see "Revisit when…".
+- **Flux Schnell → fast-sdxl.** Incidental model choice during implementation. Cost per image and latency are comparable.
+
+Net effect: simpler stack, same observable behavior for Phase 1 — *with one consequential omission* (invalidation).
+
+---
+
+## Unmet Phase 1 commitments
+
+These are not deferrals — they are gaps that should be closed before Phase 1 beta is considered complete, because they tie directly to the world-evolution premise.
+
+### 1. Ripple-score-based cache invalidation
+
+**Why it matters:** the design premise is a causally evolving multiverse where node visuals reflect accumulated state. With static `(seed, node_id)` cache keys, a node's image is fixed at first discovery and never reflects subsequent causal pressure or interaction history. The `ripple_score` and `interaction_summary` fields already exist on `SpatialNode` but are not consumed by image generation.
+
+**Smallest viable implementation:**
+- Include a coarse bucket of `ripple_score` (e.g., rounded to 0.3) and an `interaction_summary` token in the cache key
+- Or: keep the simple key, but check `ripple_score` delta against the cached row's stored score and regenerate when delta > 0.3
+- Either approach is single-digit lines of change
+
+### 2. Structured prompt assembly
+
+**Why it matters:** the current prompt is a flat property dump. Per-level baselines (`HIERARCHY_STYLES`) and ripple/history weighting would make the visual register actually distinct across the eleven scales — which is a stated design goal in the README ("each with its own aesthetic register").
+
+**Lower priority than (1)** — visuals are serviceable now, and this is iterative.
+
+---
+
+## Revisit when…
+
+Move from fal.ai-URL caching to first-party storage (R2 or equivalent) when *any* of:
+
+- fal.ai URL expiration becomes observable (cached URLs return 404)
+- Image volume × storage cost exceeds R2's free tier (10 GB) — at ~150 KB/image that's ~70k images
+- Compliance or branding requires hosting our own assets
+- We need image transformations (resize, format conversion) at request time
+
+Move from SQLite to Redis for the cache layer when:
+
+- Multi-process or multi-host deployment ships (parallel to ADR-001's persistence trigger)
+- Cache hit-rate metrics or per-key TTLs become operationally useful
+
+Reconsider the model (fast-sdxl → Flux Schnell or other) when:
+
+- Image quality becomes a recurring user complaint
+- Cost per image drifts materially against budget
+
+---
+
+## Cost Model (current)
 
 | Item | Cost |
 |------|------|
-| fal.ai Flux Schnell | ~$0.003 / image |
-| 100 beta players × 10 node discoveries / session | ~$3.60 / session in generation |
-| Target monthly infrastructure budget | < $20 (generation + Redis + R2) |
+| fal.ai `fast-sdxl` | ~$0.003 / image (comparable to original Flux Schnell estimate) |
+| 100 beta players × 10 node discoveries / session | ~$3 / session in generation |
+| Storage | $0 (fal.ai-hosted URLs cached as strings in SQLite) |
+| Target monthly budget | < $20 (generation only, until R2 trigger fires) |
 
 ---
 
-## Phase 2 Upgrade Path (not Phase 1)
+## Phase 2 Upgrade Path (unchanged)
 
 - **IP-Adapter reference conditioning** — when player return frequency makes consistency a retention issue
 - **Style zone LoRAs** (~$10–30 one-time training per zone) — when world visual coherence becomes a competitive priority

--- a/docs/decisions/ADR-002-image-generation.md
+++ b/docs/decisions/ADR-002-image-generation.md
@@ -48,10 +48,14 @@ The model swap to `fast-sdxl` is incidental — comparable cost and quality; rev
 
 | Step | As built | Original prescription | Status |
 |------|----------|-----------------------|--------|
-| Generate | Once per `(seed, node_id)` | Once on node discovery | ✓ matches intent |
-| Cache | SQLite (`persistence.cache_image`), keyed to `f"{seed}:{node_id}"` | Redis hash, keyed to `node_id` | Backend swap — see "Why" |
-| Invalidate | Never | When `ripple_score` shift > 0.3 | **Not implemented — see "Unmet Phase 1 commitments"** |
+| Generate | Once per `(seed, node_id, history_bucket)` | Once on node discovery | ✓ matches intent |
+| Cache | SQLite (`persistence.cache_image`), keyed to `f"{seed}:{node_id}:{history_bucket}"` | Redis hash, keyed to `node_id` | Backend swap — see "Why" |
+| Invalidate | Cache key includes `len(get_node_history(seed, node_name)) // 5`; image regenerates after every 5 recorded interactions | When `ripple_score` shift > 0.3 | ✓ same intent, different signal — see "Invalidation signal" |
 | Store | fal.ai-hosted URL (string in SQLite) | Cloudflare R2 as `.webp` | Backend swap — see "Why" |
+
+### Invalidation signal
+
+The original ADR keyed invalidation off `ripple_score`, a field on `SpatialNode`. That field exists but nothing in the causality engine currently mutates it, so keying on it would never invalidate. Until causality→ripple_score is wired, the cache key includes a coarse bucket of accumulated interaction history (`world_mutations` rows for the node, divided by 5). This delivers the user-visible behaviour the ADR promised — visuals refresh as a node accumulates state — using infrastructure that already exists, and the cache contract stays stable when a richer signal swaps in later.
 
 ---
 
@@ -69,14 +73,9 @@ Net effect: simpler stack, same observable behavior for Phase 1 — *with one co
 
 These are not deferrals — they are gaps that should be closed before Phase 1 beta is considered complete, because they tie directly to the world-evolution premise.
 
-### 1. Ripple-score-based cache invalidation
+### 1. ~~Ripple-score-based cache invalidation~~ — closed via interaction-history signal
 
-**Why it matters:** the design premise is a causally evolving multiverse where node visuals reflect accumulated state. With static `(seed, node_id)` cache keys, a node's image is fixed at first discovery and never reflects subsequent causal pressure or interaction history. The `ripple_score` and `interaction_summary` fields already exist on `SpatialNode` but are not consumed by image generation.
-
-**Smallest viable implementation:**
-- Include a coarse bucket of `ripple_score` (e.g., rounded to 0.3) and an `interaction_summary` token in the cache key
-- Or: keep the simple key, but check `ripple_score` delta against the cached row's stored score and regenerate when delta > 0.3
-- Either approach is single-digit lines of change
+**Resolved.** Cached images now refresh as a node accumulates interactions; see the "Invalidation signal" subsection above. The original `ripple_score` field remains unused — when causality→ripple_score is wired up, the signal can swap in without changing the cache contract.
 
 ### 2. Structured prompt assembly
 

--- a/frontend/src/components/SceneView.jsx
+++ b/frontend/src/components/SceneView.jsx
@@ -14,6 +14,7 @@ export default function SceneView({ node, players, onNavigate, onNavigateUp, can
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         node_id: node.id ?? node.name,
+        node_name: node.name,
         node_level: node.level,
         node_properties: node.properties ?? {},
         seed: seed ?? 0,

--- a/server/handlers.py
+++ b/server/handlers.py
@@ -374,13 +374,27 @@ class Handler(BaseHTTPRequestHandler):
         import urllib.request as _urlreq
 
         node_id    = str(body.get("node_id",    "unknown"))[:128]
+        node_name  = str(body.get("node_name",  ""))[:128]
         node_level = str(body.get("node_level", "Room"))[:64]
         node_props = body.get("node_properties", {})
         if not isinstance(node_props, dict):
             node_props = {}
         seed       = str(body.get("seed", "0"))[:16]
 
-        node_key = f"{seed}:{node_id}"
+        # Cache key includes a coarse bucket of accumulated interaction
+        # history so cached images regenerate as the node's causal state
+        # evolves. Using history count as the signal until causality→
+        # ripple_score is wired up (see ADR-002).
+        try:
+            seed_int = int(seed)
+        except ValueError:
+            seed_int = 0
+        history_bucket = 0
+        if seed_int and node_name:
+            history = persistence.get_node_history(seed_int, node_name, limit=1000)
+            history_bucket = len(history) // 5
+
+        node_key = f"{seed}:{node_id}:{history_bucket}"
         cached = persistence.get_cached_image(node_key)
         if cached:
             return self._send_json({"url": cached})


### PR DESCRIPTION
## Summary

The project documentation had drifted significantly behind the code, and two ADRs prescribed infrastructure (FastAPI, Redis, R2) that was never wired up. This branch reconciles the docs with reality, then closes one substantive Phase 1 commitment that the reconciliation surfaced.

### Documentation alignment
- **README.md** — fixed hierarchy count (11, not 10); refreshed Current State table to cover WebSocket multiplayer, persistent agent memory, agent-to-agent encounters, the PixiJS frontend, the full REST surface, and the 116-test suite; expanded Setup with the env-var matrix and frontend dev steps.
- **docs/architecture/overview.md** — dropped "Planned" labels for `consciousness/`, `causality/`, `persistence/`, `server/`, and `interface/` (all shipped); documented their actual module APIs; added a `frontend/` section.
- **docs/CHANGELOG.md** — extended Unreleased with WebSocket multiplayer, browser frontend, persistent agent memory, agent-to-agent encounters, history-aware consciousness, server module split, easter eggs, the security hardening pass, and the puzzle-system rework.

### ADR revisions
- **ADR-001** — corrects the stack from "FastAPI WebSockets + Redis + Cloudflare R2" to what actually shipped: stdlib `http.server` + threaded WebSocket + SQLite. The stdlib choice honors the original "Python-primary, no new runtime required" constraint *more strictly* than FastAPI would. Adds a "Revisit when…" section with concrete migration triggers (concurrent WS clients, validation pressure, multi-host deploy) so the deferral is tracked rather than implicit.
- **ADR-002** — corrects the model (`fast-sdxl`, not Flux Schnell), the cache (SQLite, not Redis), and the storage (fal.ai-hosted URLs, not R2 `.webp`). Initially called out ripple-score-based cache invalidation as an unmet Phase 1 commitment; that commitment is now closed (see below).

### Closing the ADR-002 cache-invalidation gap
Investigation showed the original plan keyed invalidation off `SpatialNode.ripple_score`, but nothing in the causality engine mutates that field today — keying on it would never invalidate. Rather than ship dead-field plumbing, the cache key now includes a coarse bucket of recorded interaction history (`world_mutations` rows for the node, divided by 5):

```
node_key = f"{seed}:{node_id}:{history_bucket}"
```

Cached scene images now refresh after every ~5 recorded interactions on a node. The cache contract stays stable when a richer signal (`ripple_score`, `interaction_summary`, etc.) is wired in later.

### `.env.example` cleanup
Removed `REDIS_URL` and the five `R2_*` variables that no code reads. They were misleading anyone setting up the project into provisioning infrastructure that wasn't wired in. They will reappear if/when the ADR-001 migration triggers fire. Also corrected the fal.ai model reference.

## Commits

1. `c750a73` — docs: align README, architecture, and changelog with current state
2. `8baf65e` — docs(adr-001): revise to reflect what actually shipped
3. `39396e5` — docs(adr-002): revise to record what shipped and call out unmet commitments
4. `e0586ff` — feat(image): refresh cached scene image as a node accumulates interactions
5. `1618abc` — chore(env): drop unused REDIS_URL and R2_* from .env.example

## Test plan

- [x] All 116 existing tests pass (`pytest tests/ -q`)
- [ ] Smoke-test `/image` against a fresh world: first request generates, repeat request returns cached URL
- [ ] After 5+ `PUZZLE_SOLVED` mutations on a node (currently the only event that calls `record_mutation`), confirm `/image` returns a freshly generated URL rather than the old cached one
- [ ] Confirm existing cache rows are orphaned (different key suffix) — first request per node after deploy will incur a one-time fal.ai call
- [ ] Verify `frontend/` dev server still loads scenes (`cd frontend && npm run dev`)

## Notes for review

- **Behavioural one-time cost on deploy:** existing cached image rows have keys without the new `history_bucket` suffix, so the first `/image` request per node after merge will regenerate. Acceptable, but worth knowing.
- **Today's only `record_mutation` caller is `PUZZLE_SOLVED`** (`server/handlers.py:563`). So in practice the new invalidation kicks in on puzzle solves only. Once `AGENT_VISIT`, `PLAYER_SPEAK`, etc. are wired into `record_mutation`, this code starts refreshing on those too without further changes — which is the intended shape.
- **`docs/roadmap/phase-1-beta.md` was not touched.** Several items there (multiplayer presence, graph traversal end-to-end, fal.ai scene images) appear shipped, but I held off without explicit guidance on whether to mark them done in-place or leave the roadmap as a historical Phase 1 record.

https://claude.ai/code/session_01TohDgt1Z4XTrrn9hF37jEw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TohDgt1Z4XTrrn9hF37jEw)_