### PR TITLE
docs: address medium-tier audit findings (stack doc, roadmap, naming, CLI default)

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -41,8 +41,9 @@ A shared persistent multiverse inhabited simultaneously by human players and AI 
 ## Components
 
 ### `multiverse/` — World Model
-- **`node.py`** — `SpatialNode`: recursive data structure with name, level, children, properties, and interaction history
+- **`node.py`** — `SpatialNode`: recursive data structure with id, name, level, children, properties; per-node interaction history is stored in `persistence/` (`world_mutations` table) and accessed via `persistence.get_node_history`
 - **`generator.py`** — deterministic PCG with named locations, variable branching, and level-specific property templates
+- **`utils.py`** — tree helpers: `count_nodes`, `find_node`, `build_depth_map`
 
 ### `consciousness/` — Node Voice Layer
 Claude-powered persona system. Each node's voice is seeded by its properties and accumulated interaction history. Nodes respond in character, reference past visitors, and hold perspective.

--- a/docs/design/game-design.md
+++ b/docs/design/game-design.md
@@ -1,4 +1,4 @@
-# Game Design Document — Nested World Adventure
+# Game Design Document — Nested Worlds Adventure
 
 ---
 
@@ -33,6 +33,8 @@ Node visual style is programmatically determined by a property matrix. Style dri
 | Corrupted / destructive | Glitch art, dark expressionist |
 | Puzzle node | Escher-like, geometric, op art |
 | High ripple weight | Psychedelic, saturated, unstable |
+
+> **Implementation status.** This matrix is aspirational. Today the prompt assembly in `server/handlers.py::_do_image` is a flat dump of the first six node properties — none of these style signals are wired in. The cache key buckets `len(get_node_history) // 5` so visuals do refresh as a node accumulates state, but the *style* of refresh is not yet differentiated. Closing this gap is tracked in ADR-002 as "Unmet Phase 1 commitments §2 — Structured prompt assembly".
 
 ---
 

--- a/docs/infrastructure/stack.md
+++ b/docs/infrastructure/stack.md
@@ -1,10 +1,26 @@
 # Infrastructure Stack
 
+The as-built Phase 1 stack. Diverges from the original ADRs in three places (FastAPI → stdlib `http.server`, Redis → SQLite, Cloudflare R2 → fal.ai-hosted URL caching). See ADR-001 and ADR-002 for the rationale and revisit triggers.
+
 | Layer | Service | Notes |
 |-------|---------|-------|
-| Frontend | React + PixiJS | Scene rendering + UI shell |
-| Backend | FastAPI + WebSockets | Python-primary, existing |
-| Image generation | fal.ai (Flux Schnell) | Pay-as-you-go, no commitment |
-| Cache | Redis (Railway or Render free tier) | Scene hash + session state |
-| Image storage | Cloudflare R2 | Free tier 10 GB, zero egress |
-| Multiplayer state | FastAPI WebSockets | Room-based, Python-native |
+| Browser frontend | React + PixiJS + Vite (`frontend/`) | Scene rendering, hotspots, multiplayer presence; built into `static/app/` |
+| Browser frontend (alt) | Vanilla D3 (`static/index.html` + `static/explorer.js`) | Tree explorer served at `/` directly by the Python server |
+| Backend HTTP/WebSocket | Python stdlib `http.server` + `ThreadingMixIn` (`server/`) | Threaded, no external HTTP framework; security headers + CSP + body/frame caps |
+| WebSocket protocol | Hand-rolled framing via `struct` (`server/protocol.py`) | Subset we use: text frames + ping; ~55 lines |
+| Multiplayer state | In-memory rooms (`server/rooms.py`) | Per-seed presence, broadcast, chat |
+| Image generation | fal.ai (`fal-ai/fast-sdxl`) via `urllib` | Pay-as-you-go, no SDK dependency |
+| Image cache + storage | SQLite (`persistence.cache_image`) | Cache key includes a coarse interaction-history bucket so visuals refresh as the node evolves |
+| Persistence | SQLite (`persistence/`) | World state, agent runs, agent memory, node interaction history, world mutations, image cache |
+| LLM | Anthropic (Claude) via official SDK | Node consciousness (`/speak`) and agent personas |
+
+## Runtime requirements
+
+- Python 3.11+ (stdlib server, no external HTTP framework)
+- Node 22+ (only for building the React frontend; not required to run the server)
+- `ANTHROPIC_API_KEY` for `/speak`
+- `FAL_KEY` for AI scene backgrounds (optional — frontend gracefully degrades)
+
+## Migration triggers
+
+See ADR-001 ("Revisit when…") and ADR-002 ("Revisit when…") for the conditions under which any layer of this stack should be replaced (concurrent WebSocket scaling, multi-host deployment, fal.ai URL expiration, etc.).

--- a/docs/roadmap/phase-1-beta.md
+++ b/docs/roadmap/phase-1-beta.md
@@ -1,18 +1,30 @@
 # Phase 1 Beta Scope
 
----
-
-## In Scope
-
-1. **AI-generated scene image per node** — Flux Schnell via fal.ai, consistent style prompt per node type
-2. **Clickable hotspots with hover states** — PixiJS
-3. **Text panel alongside scene** — node description, history fragments, available actions
-4. **Basic multiplayer presence** — other player markers visible in scene
-5. **Graph traversal end-to-end** — navigate between nodes, state persists across sessions
+Status reflects what shipped to `main`. See the [CHANGELOG](../CHANGELOG.md) for commit-level detail.
 
 ---
 
-## Out of Scope for Phase 1
+## Shipped
+
+1. **AI-generated scene image per node** — `fal-ai/fast-sdxl` via fal.ai (model swap from Flux Schnell — see ADR-002), prompt assembled per-node from level + properties, cached in SQLite
+2. **Clickable hotspots with hover states** — PixiJS scenes rendered in `frontend/`, child nodes navigable
+3. **Text panel alongside scene** — node level / name / properties + presence + event feed in the React UI
+4. **Basic multiplayer presence** — WebSocket-based; other player markers and movement broadcast in real time
+5. **Graph traversal end-to-end** — REST + WebSocket; world state persists in SQLite across sessions
+6. **Causal-event broadcasting** — `causality/` events fan out to all connected clients
+7. **Persistent agent memory** — agents remember visited nodes across runs
+
+---
+
+## Not yet shipped (carry-over to Phase 1 close-out)
+
+- **Cache invalidation by interaction richness.** Currently the cache key buckets `len(get_node_history) // 5`, which only changes for nodes that get `record_mutation`-recorded events. Today only `PUZZLE_SOLVED` calls that. Wiring `AGENT_VISIT`, `PLAYER_SPEAK`, etc. into `record_mutation` would make the visual evolution premise actually function across the world.
+- **Structured prompt assembly per level** — current prompt is a flat property dump (see ADR-002 "Unmet Phase 1 commitments §2"). Per-level `HIERARCHY_STYLES` baselines would make the eleven scales visually distinct.
+- **React client name prompt** — the React app at `/app/` currently hardcodes the player name `"Traveller"`; the D3 explorer at `/` prompts via a join modal. They should match.
+
+---
+
+## Out of Scope for Phase 1 (deferred to Phase 2)
 
 - Animated ripple effects on the multiverse graph
 - Cooperative mechanics in-product
@@ -20,3 +32,4 @@
 - IP-Adapter scene conditioning
 - Style zone LoRAs
 - Pan animation polish
+- First-party image hosting (R2 or equivalent) — see ADR-002 "Revisit when…" for the trigger

--- a/main.py
+++ b/main.py
@@ -128,7 +128,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_world = sub.add_parser("world", help="Generate and print the world hierarchy")
-    p_world.add_argument("--depth", type=int, default=10, help="Max hierarchy depth (default: 10)")
+    p_world.add_argument("--depth", type=int, default=11, help="Max hierarchy depth (default: 11)")
     p_world.add_argument("--min-breadth", type=int, default=1, dest="min_breadth")
     p_world.add_argument("--max-breadth", type=int, default=3, dest="max_breadth")
     p_world.set_defaults(func=cmd_world)

--- a/setup.sh
+++ b/setup.sh
@@ -11,4 +11,4 @@ npm --version
 # Frontend dependencies (once package.json exists)
 [ -f frontend/package.json ] && cd frontend && npm install && cd ..
 
-echo "Nested World Adventure environment ready ✓"
+echo "Nested Worlds Adventure environment ready ✓"


### PR DESCRIPTION
## Context

Follow-up to PR #28. The repo audit returned three tiers of findings; this PR addresses six of the medium-tier items (doc/config drift that misleads contributors but doesn't break runtime behavior). High-tier items shipped in PR #28; remaining medium items (test coverage gaps, hardcoded React client name, possibly-dead enum members) are deferred.

## Findings addressed

| # | Issue | Resolution |
|---|---|---|
| 6 | `docs/infrastructure/stack.md` still describes FastAPI + Redis + R2 | Rewrote to match the as-built stack (stdlib `http.server`, SQLite, fal.ai URL caching). Cross-references ADR-001/002 for revisit triggers. |
| 7 | `docs/roadmap/phase-1-beta.md` lists shipped items as "in scope" | Split into "Shipped" / "Not yet shipped" / "Out of Scope". Carry-over items (broader `record_mutation` event coverage, structured prompt assembly, React client name prompt) are flagged explicitly. |
| 8 | `docs/design/game-design.md` uses pre-rename "Nested World" + references unused `ripple_score` signals | Fixed title. Added an "Implementation status" callout to the Adaptive Style System matrix making clear the matrix is aspirational; cross-references ADR-002 "Unmet Phase 1 commitments §2". |
| 10 | `docs/architecture/overview.md:44` mis-describes `SpatialNode` | Corrected field list. Interaction history is not on the node; it's in `persistence.world_mutations` accessed via `get_node_history`. Also added `multiverse/utils.py` to the component list. |
| 11 | `main.py world --depth` default is 10, hierarchy is 11 | `python main.py world` was silently truncating one level. Changed default to 11; updated help string. |
| 12 | `setup.sh:14` echoes pre-rename "Nested World Adventure" (singular) | Changed to "Nested Worlds Adventure" to match `pyproject.toml`, README, CLI banner, etc. |

## Verification

- All 116 tests pass.
- No code paths affected — runtime behavior is identical except for `python main.py world` which now generates 11 levels by default instead of 10.

## Test plan

- [x] All 116 existing tests pass
- [ ] `python main.py world` runs cleanly and produces 11-level hierarchy
- [ ] `bash setup.sh` echoes the corrected name
- [ ] All four doc files render correctly on GitHub

## Deferred medium-tier items

These were in the audit's medium tier but deferred to keep this PR scoped and reviewable:

- **#13** Duplicate easter-egg assets in `puzzles/easter-eggs/` (unreachable) and `static/easter-egg/` (served) — destructive cleanup, want to confirm intent first
- **#14, #15** Test coverage gaps (`agent_memory` / `node_images` schema asserts; `server/protocol.py` and `server/rooms.py` have no tests) — separate test-suite PR
- **#16** React client hardcodes player name `"Traveller"`; D3 client prompts. Inconsistent UX — small UI feature, separate PR
- **#17, #18, #19** `consciousness.describe()` exported but unused; `multiverse/__init__.py` empty; possibly-dead `PuzzleKind` enum members — code cleanup pass

https://claude.ai/code/session_01TohDgt1Z4XTrrn9hF37jEw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TohDgt1Z4XTrrn9hF37jEw)_