### PR TITLE
Rename the deployment identity to the brand: enfolded-beta

### DIFF
--- a/docs/infrastructure/fly-deployment.md
+++ b/docs/infrastructure/fly-deployment.md
@@ -115,7 +115,7 @@ concurrent WebSockets via `NESTED_WORLDS_MAX_WS_CONNECTIONS` /
 `NESTED_WORLDS_MAX_WS_PER_IP`.
 
 ```toml
-app = "nested-worlds-beta"          # change to your unique app name
+app = "enfolded-beta"          # change to your unique app name
 primary_region = "iad"              # pick the region closest to your testers
 
 [build]
@@ -147,7 +147,7 @@ primary_region = "iad"              # pick the region closest to your testers
     grace_period = "10s"
 
 [mounts]
-  source = "nested_worlds_data"
+  source = "enfolded_data"
   destination = "/data"
 
 [[vm]]
@@ -174,10 +174,10 @@ Run these from the repo root.
 
 ```bash
 # Create the app (no deploy yet), matching the name you set in fly.toml.
-fly apps create nested-worlds-beta
+fly apps create enfolded-beta
 
 # Provision the persistent volume in the same region as the app.
-fly volumes create nested_worlds_data --region iad --size 1
+fly volumes create enfolded_data --region iad --size 1
 
 # Set runtime secrets. These never appear in logs or the image.
 # FAL_KEY and SENTRY_DSN are optional — omit either line freely.
@@ -208,10 +208,10 @@ deploy takes ~3-5 minutes.
 
 ```bash
 # Should return {"status": "ok"}; /health is exempt from the invite gate.
-curl https://nested-worlds-beta.fly.dev/health
+curl https://enfolded-beta.fly.dev/health
 
 # Open the bundled UI in a browser.
-open https://nested-worlds-beta.fly.dev/app
+open https://enfolded-beta.fly.dev/app
 
 # Tail logs in another terminal.
 fly logs
@@ -280,7 +280,7 @@ fly ssh console -C "python main.py invite mint --name Alice --note 'design partn
 ```
 
 The output includes a ready-to-share URL of the form
-`https://nested-worlds-beta.fly.dev/app?key=nw_<hex>&name=Alice`.
+`https://enfolded-beta.fly.dev/app?key=nw_<hex>&name=Alice`.
 Send one to each tester.
 
 To audit:

--- a/fly.toml
+++ b/fly.toml
@@ -9,7 +9,7 @@
 # reachable without passing through a proxy that overwrites Fly-Client-IP —
 # a client could otherwise mint a fresh rate-limit bucket per request.
 
-app = "nested-worlds-beta"          # change to your unique app name
+app = "enfolded-beta"          # change to your unique app name
 primary_region = "iad"              # pick the region closest to your testers
 
 [build]
@@ -42,7 +42,7 @@ primary_region = "iad"              # pick the region closest to your testers
     grace_period = "10s"
 
 [mounts]
-  source = "nested_worlds_data"
+  source = "enfolded_data"
   destination = "/data"
 
 [[vm]]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,7 +11,7 @@
 #   FLY_APP=my-app scripts/deploy.sh  # target a differently named app
 set -euo pipefail
 
-APP="${FLY_APP:-nested-worlds-beta}"
+APP="${FLY_APP:-enfolded-beta}"
 STAMP="$(date -u +%Y%m%d-%H%M%S)"
 KEEP=5
 


### PR DESCRIPTION
The Fly app name is the player-visible identity — until the custom domain lands, every invite URL says `<app>.fly.dev` — and pre-first-deploy is the only free moment to align it with the brand, before the name is baked into the volume attachment, certs, and shared links.

- `fly.toml`: `app = "enfolded-beta"`, volume source `enfolded_data`
- `scripts/deploy.sh`: `FLY_APP` default → `enfolded-beta`
- Runbook: every example command and URL (`fly apps create`, `fly volumes create`, smoke-test URLs, invite-URL format) now says `enfolded-beta`

**Deliberately not renamed**: the internal namespace — `NESTED_WORLDS_*` env vars (17 files), the `~/.nested-worlds/` DB path, `nested_worlds.*` logger names, and `nw_` invite-key/localStorage prefixes. Those are invisible to players, and sweeping them would be churn and breakage risk for zero functional value; "nested worlds" also remains accurate as the descriptive subtitle of the project.

585 Python tests pass, including the `tests/test_deploy_config.py` guards on the committed `fly.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1Y9oSPq8qc42KoHPwaZAk

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1Y9oSPq8qc42KoHPwaZAk)_